### PR TITLE
Changed example files to load relative scheme (https)

### DIFF
--- a/js/index.htm
+++ b/js/index.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en" xmlns="//www.w3.org/1999/xhtml">
 <head>
     <meta charset="utf-8" />
     <title></title>
@@ -9,7 +9,7 @@
 <body>
     <div id="imageInfo">Image Header Info</div>
     <div id="currentPV">Hover over to see current pixel value</div>
-    <input id="mapUrl" type="text" style="width:90%" value="http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer/tile/0/0/0" onchange="showTile()">
+    <input id="mapUrl" type="text" style="width:90%" value="//elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer/tile/0/0/0" onchange="showTile()">
     <div>
         <canvas width="100" height="100" id="imageCanvas"></canvas>
     </div>

--- a/js/leaflet.html
+++ b/js/leaflet.html
@@ -6,8 +6,8 @@
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
     <!-- Load Leaflet from CDN-->
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
-    <script src="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>
+    <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
+    <script src="//cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>
     <!--script src="../node_modules/leaflet/dist/leaflet-src.js"></script-->
 
     <script src="./LercCodec.js"></script>
@@ -68,7 +68,7 @@
       // ctx.fillStyle = '#00FFFF';
       // ctx.fillRect(0, 0, 257, 257);
       var canvasPos = canvas.getBoundingClientRect();
-      var url = 'http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer/tile/' +
+      var url = '//elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer/tile/' +
       zoom +
       '/' +
       tilePoint.y +


### PR DESCRIPTION
So examples can be served from `http` or `https`