### PR TITLE
Removed second variable definition

### DIFF
--- a/src/Lerc/Lerc2/Huffman.cpp
+++ b/src/Lerc/Lerc2/Huffman.cpp
@@ -528,7 +528,7 @@ bool Huffman::ConvertCodesToCanonical()
   int i = 0;
   while (i < tableSize && sortVec[i].first > 0)
   {
-    int index = sortVec[i++].second;
+    index = sortVec[i++].second;
     short delta = codeLen - m_codeTable[index].first;
     codeCanonical >>= delta;
     codeLen -= delta;


### PR DESCRIPTION
index was redefined, probably a mistake