### PR TITLE
javascript decoder API reference fixes

### DIFF
--- a/OtherLanguages/js/LercDecode.js
+++ b/OtherLanguages/js/LercDecode.js
@@ -1663,19 +1663,10 @@ Contributors:  Johannes Schmid, (LERC v1)
       /**
        * Decode a LERC2 byte stream and return an object containing the pixel data and optional metadata.
        *
-       * @alias module:Lerc
        * @param {ArrayBuffer} input The LERC input byte stream
        * @param {object} [options] options Decoding options
        * @param {number} [options.inputOffset] The number of bytes to skip in the input byte stream. A valid LERC file is expected at that position
        * @param {boolean} [options.returnFileInfo] If true, the return value will have a fileInfo property that contains metadata obtained from the LERC headers and the decoding process
-       * @returns {{width, height, pixelData, minValue, maxValue, maskData, fileInfo}}
-         * @property {number} width Width of decoded image
-         * @property {number} height Height of decoded image
-         * @property {object} pixelData The actual decoded image
-         * @property {number} minValue Minimum pixel value detected in decoded image
-         * @property {number} maxValue Maximum pixel value detected in decoded image
-         * @property {maskData} maskData
-         * @property {object} [fileInfo]
        */
       decode: function(/*byte array*/ input, /*object*/ options) {
         //currently there's a bug in the sparse array, so please do not set to false
@@ -1837,15 +1828,25 @@ Contributors:  Johannes Schmid, (LERC v1)
     return Lerc2Decode;
   })();
 
-
-  /************wrapper**********************************************
-   * This is a wrapper on top of the basic lerc stream decoding
-   *      used to decode multi band pixel blocks for various pixel types.
-   * decodeLercRaster(xhr.response)
-   * decodeLercRaster(xhr.response, {pixelType:"U8"}); leave pixelType out in favor of F32 for lerc1
-   * decodeLercRaster(xhr.response, {inputOffset:10}); lerc start from the 10th byte
-   * ***********************************************************/
   var Lerc = {
+    /************wrapper**********************************************/
+    /**
+     * A wrapper for decoding both LERC1 and LERC2 byte streams capable of handling multiband pixel blocks for various pixel types.
+     *
+     * @alias module:Lerc
+     * @param {ArrayBuffer} input The LERC input byte stream
+     * @param {object} [options] The decoding options below are optional.
+     * @param {number} [options.inputOffset] The number of bytes to skip in the input byte stream. A valid Lerc file is expected at that position.
+     * @param {string} [options.pixelType] (LERC1 only) Default value is F32. Valid pixel types for input are U8/S8/S16/U16/S32/U32/F32.
+     * @param {number} [options.noDataValue] (LERC1 only). It is recommended to use the returned mask instead of setting this value.
+     * @returns {{width, height, pixels, pixelType, mask, statistics}}
+       * @property {number} width Width of decoded image.
+       * @property {number} height Height of decoded image.
+       * @property {array} pixels [band1, band2, …] Each band is a typed array of width*height.
+       * @property {string} pixelType The type of pixels represented in the output.
+       * @property {mask} mask Typed array with a size of width*height, or null if all pixels are valid.
+       * @property {array} statistics [statistics_band1, statistics_band2, …] Each element is a statistics object representing min and max values
+    **/
     decode: function(encodedData, options) {
       options = options || {};
       var inputOffset = options.inputOffset || 0;

--- a/OtherLanguages/js/README.hbs
+++ b/OtherLanguages/js/README.hbs
@@ -5,7 +5,7 @@
 
 # Lerc JS
 
-> Rapid decoding for any pixel type, not just rgb or byte
+> Rapid decoding of Lerc compressed raster data for any standard pixel type, not just rgb or byte
 
 ## Usage
 
@@ -15,7 +15,10 @@ npm install 'lerc'
 ```js
 var Lerc = require('lerc');
 
-Lerc.decode(xhr.response, { returnFileInfo: true });
+Lerc.decode(xhrResponse, {
+  pixelType: "U8", // leave pixelType out in favor of F32 for lerc1
+  inputOffset: 10 // start from the 10th byte
+});
 ```
 
 ## API Reference

--- a/OtherLanguages/js/README.md
+++ b/OtherLanguages/js/README.md
@@ -5,7 +5,7 @@
 
 # Lerc JS
 
-> Rapid decoding for any pixel type, not just rgb or byte
+> Rapid decoding of Lerc compressed raster data for any standard pixel type, not just rgb or byte
 
 ## Usage
 
@@ -15,7 +15,10 @@ npm install 'lerc'
 ```js
 var Lerc = require('lerc');
 
-Lerc.decode(xhr.response, { returnFileInfo: true });
+Lerc.decode(xhrResponse, {
+  pixelType: "U8", // leave pixelType out in favor of F32 for lerc1
+  inputOffset: 10 // start from the 10th byte
+});
 ```
 
 ## API Reference
@@ -28,28 +31,28 @@ a module for decoding LERC blobs
 <a name="exp_module_Lerc--decode"></a>
 
 ### decode(input, [options]) ⇒ <code>Object</code> ⏏
-Decode a LERC2 byte stream and return an object containing the pixel data and optional metadata.
+A wrapper for decoding both LERC1 and LERC2 byte streams capable of handling multiband pixel blocks for various pixel types.
 
 **Kind**: Exported function
 
 | Param | Type | Description |
 | --- | --- | --- |
 | input | <code>ArrayBuffer</code> | The LERC input byte stream |
-| [options] | <code>object</code> | options Decoding options |
-| [options.inputOffset] | <code>number</code> | The number of bytes to skip in the input byte stream. A valid LERC file is expected at that position |
-| [options.returnFileInfo] | <code>boolean</code> | If true, the return value will have a fileInfo property that contains metadata obtained from the LERC headers and the decoding process |
+| [options] | <code>object</code> | The decoding options below are optional. |
+| [options.inputOffset] | <code>number</code> | The number of bytes to skip in the input byte stream. A valid Lerc file is expected at that position. |
+| [options.pixelType] | <code>string</code> | (LERC1 only) Default value is F32. Valid pixel types for input are U8/S8/S16/U16/S32/U32/F32. |
+| [options.noDataValue] | <code>number</code> | (LERC1 only). It is recommended to use the returned mask instead of setting this value. |
 
-**Result Object Properties**
+**Result Object**
 
 | Name | Type | Description |
 | --- | --- | --- |
-| width | <code>number</code> | Width of decoded image |
-| height | <code>number</code> | Height of decoded image |
-| pixelData | <code>object</code> | The actual decoded image |
-| minValue | <code>number</code> | Minimum pixel value detected in decoded image |
-| maxValue | <code>number</code> | Maximum pixel value detected in decoded image |
-| maskData | <code>maskData</code> |  |
-| fileInfo | <code>object</code> |  |
+| width | <code>number</code> | Width of decoded image. |
+| height | <code>number</code> | Height of decoded image. |
+| pixels | <code>array</code> | [band1, band2, …] Each band is a typed array of width*height. |
+| pixelType | <code>string</code> | The type of pixels represented in the output. |
+| mask | <code>mask</code> | Typed array with a size of width*height, or null if all pixels are valid. |
+| statistics | <code>array</code> | [statistics_band1, statistics_band2, …] Each element is a statistics object representing min and max values |
 
 * * *
 

--- a/OtherLanguages/js/index.htm
+++ b/OtherLanguages/js/index.htm
@@ -37,7 +37,7 @@
       xhr.onreadystatechange = function () {
         if (xhr.readyState == 4 && xhr.status == 200) {
           var t0 = new Date();
-          var decodedPixelBlock = Lerc.decode(xhr.response, { returnMask: true });
+          var decodedPixelBlock = Lerc.decode(xhr.response);
           var duration = (new Date()) - t0;
           width = decodedPixelBlock.width;
           height = decodedPixelBlock.height;

--- a/OtherLanguages/js/package.json
+++ b/OtherLanguages/js/package.json
@@ -2,9 +2,9 @@
   "name": "lerc",
   "browser": "LercDecode.js",
   "bugs": {
-    "url": "https://github.com/esri/lerc"
+    "url": "https://github.com/esri/lerc/issues"
   },
-  "description": "Rapid decoding for any pixel type, not just rgb or byte",
+  "description": "Rapid decoding of Lerc compressed raster data for any standard pixel type.",
   "version": "1.0.0",
   "author": "Esri <dev_tools@esri.com> (http://developers.arcgis.com)",
   "contributors": [


### PR DESCRIPTION
* start surfacing the jsdoc for the wrapper function in the API reference. (not the lerc2 decoder)
* recompile README

cc/ @wju 