### PR TITLE
fix require statement in node snippet

### DIFF
--- a/OtherLanguages/js/README.hbs
+++ b/OtherLanguages/js/README.hbs
@@ -9,6 +9,9 @@
 
 ## Browser
 
+```html
+<script type="text/javascript" src="./LercDecode.js"></script>
+```
 ```js
 Lerc.decode(xhrResponse, {
   pixelType: "U8", // leave pixelType out in favor of F32 for lerc1
@@ -23,7 +26,7 @@ npm install 'lerc'
 ```
 ```js
 var http = require('http');
-var Lerc = require('./LercDecode');
+var Lerc = require('lerc');
 
 http.get('http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer/tile/0/0/0', function (res) {
   var data = [];

--- a/OtherLanguages/js/README.md
+++ b/OtherLanguages/js/README.md
@@ -9,6 +9,9 @@
 
 ## Browser
 
+```html
+<script type="text/javascript" src="./LercDecode.js"></script>
+```
 ```js
 Lerc.decode(xhrResponse, {
   pixelType: "U8", // leave pixelType out in favor of F32 for lerc1
@@ -23,7 +26,7 @@ npm install 'lerc'
 ```
 ```js
 var http = require('http');
-var Lerc = require('./LercDecode');
+var Lerc = require('lerc');
 
 http.get('http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer/tile/0/0/0', function (res) {
   var data = [];


### PR DESCRIPTION
i jinxed myself when i said that #28 was going to be the last item before publishing to npm.

sometime during my own testing i switched from [symlinking](https://docs.npmjs.com/cli/link) the package to just testing it directly and afterward forgot to update the `require()` statement to what will be appropriate for actual consumers.

sorry for all the tiny pull requests.  i'm perhaps *too aware* of the fact that individual npm releases cannot be modified after initial publication.