### PR TITLE
1.0.1 release prep and script to automate publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### No entries yet
 
+### Fixed - 2017-02-18
+
+* resolved a Huffman code table parsing issue in JavaScript decoder [#31](https://github.com/Esri/lerc/pull/31)
+
 ## 1.0 - 2016-11-30
 
 ### Milestones reached

--- a/OtherLanguages/js/CHANGELOG.md
+++ b/OtherLanguages/js/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.1 - 2017-02-18
+
+### Fixed
+
+* resolved a Huffman code table parsing issue [#31](https://github.com/Esri/lerc/pull/31)
+
 ## 1.0 - 2016-11-30
 
 - This LERC API JavaScript decoder is in sync with ArcMap 10.5 and ArcGIS Pro 1.4. LERC encoded binary blobs from any previous version of ArcMap or ArcGIS Pro can be read / decoded as well.

--- a/OtherLanguages/js/package.json
+++ b/OtherLanguages/js/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/esri/lerc/issues"
   },
   "description": "Rapid decoding of Lerc compressed raster data for any standard pixel type.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Esri <dev_tools@esri.com> (http://developers.arcgis.com)",
   "contributors": [
     "Johannes Schmid",
@@ -13,6 +13,7 @@
     "Wenxue Ju"
   ],
   "devDependencies": {
+    "gh-release": "^2.2.1",
     "jsdoc-to-markdown": "^2.0.1",
     "jshint": "^2.9.4",
     "uglify-js": "^2.7.5"
@@ -23,11 +24,12 @@
   "readmeFilename": "README.md",
   "repository": {
     "type": "git",
-    "url": "https://github.com:Esri/lerc.git"
+    "url": "https://github.com/Esri/lerc.git"
   },
   "scripts": {
     "lint": "jshint LercDecode.js",
     "build": "uglifyjs LercDecode.js -o LercDecode.min.js --comments",
-    "docs": "jsdoc2md --template README.hbs --files LercDecode.js"
+    "docs": "jsdoc2md --template README.hbs --files LercDecode.js",
+    "release": "./release.sh"
   }
 }

--- a/OtherLanguages/js/release.sh
+++ b/OtherLanguages/js/release.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# config
+VERSION=$(node --eval "console.log(require('./package.json').version);")
+NAME=$(node --eval "console.log(require('./package.json').name);")
+
+# no tests (yet)
+# npm test || exit 1
+
+# checkout temp branch for release
+git checkout -b gh-release
+
+# build files
+npm run lint && npm run build
+
+# force add files
+git add LercDecode.min.js -f
+
+# commit changes with a versioned commit message
+git commit -m "build $VERSION"
+
+# push commit so it exists on GitHub when we run gh-release
+git push upstream gh-release
+
+# run gh-release to create the tag and push release to github
+gh-release
+
+# checkout master and delete release branch locally and on GitHub
+git checkout master
+git branch -D gh-release
+git push upstream :gh-release
+
+# publish release on NPM
+npm publish


### PR DESCRIPTION
new `npm run publish` script to automate tagging patch releases on github and npm from the /js directory.

1. lints .js code and builds minified source
2. `--force` adds minified .js to version control
3. lays down a new commit and pushes upstream to a dedicated branch 
> (this requires push permission i don't have)
4. tags a patch release on GitHub using the most recent info from the JS changelog
5. tags a new patch release on npm
6. cleans up after itself