### PR TITLE
minor changelog cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,31 +7,30 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
-### Updated - 2018-02-02
+## Fixed
 
-* upgrade Lerc codec to new version Lerc 2.4.
+* resolved a Huffman code table parsing issue in JavaScript decoder [#31](https://github.com/Esri/lerc/pull/31)
+
+### Added
+
 * extend from one value per pixel to nDim values per pixel.
 * add new lossy compression option for integer types (aiming at noisy 16 bit satellite images). Cuts off noisy bit planes.
 * add more rigorous checking against buffer overrun while decoding. (This concept taken from the MRF / gdal repo.)
-* Upgraded to C++ 11, MS VS 2017, 64 bit.
-* Updated python and C# decoders.
+
+### Changed
+
+* upgrade Lerc codec to new version Lerc 2.4.
+* Updated Readme.
 * Simplified the builds.
 * Simplified the folder structure.
-* Updated Readme.
-
-[#37](https://github.com/Esri/lerc/pull/37)
+* Upgraded to C++ 11, MS VS 2017, 64 bit.
+* Updated python and C# decoders.
 
 Yet to be done:
 * update doc
 * update JS decoder.
 
-
-### Fixed - 2017-02-18
-
-* resolved a Huffman code table parsing issue in JavaScript decoder [#31](https://github.com/Esri/lerc/pull/31)
-
-
-## [1.0 - 2016-11-30]
+## [1.0](https://github.com/Esri/lerc/releases/tag/v1.0) - 2016-11-30
 
 ### Milestones reached
 - This LERC API and all language decoders (C++, C, C#, Python, JavaScript) are now in sync with these ESRI ArcGIS versions to be released soon: ESRI ArcMap 10.5, ESRI ArcGIS Pro 1.4. LERC encoded binary blobs of any previous version of ArcMap or ArcGIS Pro can be read / decoded.


### PR DESCRIPTION
* fixed a partial markdown hyperlink
* remove link to #37
* only mention dates when an actual release is tagged