### PR TITLE
RTC: Re-add invalid data handling

### DIFF
--- a/Lerc/src/Lerc/Lerc.cpp
+++ b/Lerc/src/Lerc/Lerc.cpp
@@ -147,7 +147,8 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
   lercInfo.zMax = -FLT_MAX;
 
   CntZImage cntZImg;
-  if (numBytesHeader <= numBytesBlob && cntZImg.read(&pByte, 1e12, true))    // read just the header
+  bool hasInvalidData = false;
+  if (numBytesHeader <= numBytesBlob && cntZImg.read(&pByte, hasInvalidData, 1e12, true))    // read just the header
   {
     size_t nBytesRead = pByte - pLercBlob;
     size_t nBytesNeeded = 10 + 4 * sizeof(int) + 1 * sizeof(double);
@@ -175,7 +176,7 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
 
     while (lercInfo.blobSize + numBytesHeader < numBytesBlob)    // means there could be another band
     {
-      if (!cntZImg.read(&pByte, 1e12, false, onlyZPart))
+      if (!cntZImg.read(&pByte, hasInvalidData, 1e12, false, onlyZPart))
         return (lercInfo.nBands > 0) ? ErrCode::Ok : ErrCode::Failed;    // no other band, we are done
 
       onlyZPart = true;
@@ -474,7 +475,8 @@ ErrCode Lerc::DecodeTempl(T* pData,    // outgoing data bands
         return ErrCode::BufferTooSmall;
 
       bool onlyZPart = iBand > 0;
-      if (!zImg.read(&pByte1, 1e12, false, onlyZPart))
+      bool hasInvalidData = false;
+      if (!zImg.read(&pByte1, hasInvalidData, 1e12, false, onlyZPart))
         return ErrCode::Failed;
 
       if (zImg.getWidth() != nCols || zImg.getHeight() != nRows)

--- a/Lerc/src/Lerc1Decode/CntZImage.h
+++ b/Lerc/src/Lerc1Decode/CntZImage.h
@@ -47,7 +47,7 @@ public:
   static unsigned int computeNumBytesNeededToReadHeader();
 
   /// read succeeds only if maxZError on file <= maxZError requested
-  bool read(Byte** ppByte, double maxZError, bool onlyHeader = false, bool onlyZPart = false);
+  bool read(Byte** ppByte, bool& hasInvalidData, double maxZError, bool onlyHeader = false, bool onlyZPart = false);
 
   template <class T>
   bool ConvertToMemBlock(T* arr, T noDataValue) const;


### PR DESCRIPTION
This commit adds back some handling of invalid data that we had added to
LERC when it was embedded in MR3D. This fix isn't permanent, but should
work in the interim while we lack resources to do the more significant
update to using the LERC API properly. This commit inserts a parameter,
`bool& hasInvalidData`, which we use in runtime to help determine what
to do when there are multiple elevation data sources. Some may be
incomplete, and the handling of that is more delicate than we initially
thought, with the code added in this commit playing a critical role in
other parts of the MR3D codebase. To avoid confusing situations in which
the argument intended as `hasInvalidData` instead binds to `headerOnly`
after the update, this commit moves the `hasInvalidData` parameter over
to the left, so there's no ambiguity.

Signed-off-by: Nathan LaPre <nlapre@esri.com>