### PR TITLE
tmaurer3/add_write_old_Lerc2_versions

### DIFF
--- a/src/LercLib/BitStuffer2.h
+++ b/src/LercLib/BitStuffer2.h
@@ -42,8 +42,8 @@ public:
   virtual ~BitStuffer2()  {}
 
   // dst buffer is already allocated. byte ptr is moved like a file pointer.
-  bool EncodeSimple(Byte** ppByte, const std::vector<unsigned int>& dataVec) const;
-  bool EncodeLut(Byte** ppByte, const std::vector<std::pair<unsigned int, unsigned int> >& sortedDataVec) const;
+  bool EncodeSimple(Byte** ppByte, const std::vector<unsigned int>& dataVec, int lerc2Version) const;
+  bool EncodeLut(Byte** ppByte, const std::vector<std::pair<unsigned int, unsigned int> >& sortedDataVec, int lerc2Version) const;
   bool Decode(const Byte** ppByte, size_t& nBytesRemaining, std::vector<unsigned int>& dataVec, int lerc2Version) const;
 
   static unsigned int ComputeNumBytesNeededSimple(unsigned int numElem, unsigned int maxElem);
@@ -52,6 +52,7 @@ public:
 private:
   mutable std::vector<unsigned int>  m_tmpLutVec, m_tmpIndexVec, m_tmpBitStuffVec;
 
+  static void BitStuff_Before_Lerc2v3(Byte** ppByte, const std::vector<unsigned int>& dataVec, int numBits);
   static bool BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesRemaining, std::vector<unsigned int>& dataVec, unsigned int numElements, int numBits);
   void BitStuff(Byte** ppByte, const std::vector<unsigned int>& dataVec, int numBits) const;
   bool BitUnStuff(const Byte** ppByte, size_t& nBytesRemaining, std::vector<unsigned int>& dataVec, unsigned int numElements, int numBits) const;

--- a/src/LercLib/Huffman.cpp
+++ b/src/LercLib/Huffman.cpp
@@ -122,7 +122,7 @@ bool Huffman::SetCodes(const vector<pair<unsigned short, unsigned int> >& codeTa
 
 // -------------------------------------------------------------------------- ;
 
-bool Huffman::WriteCodeTable(Byte** ppByte) const
+bool Huffman::WriteCodeTable(Byte** ppByte, int lerc2Version) const
 {
   if (!ppByte)
     return false;
@@ -154,7 +154,7 @@ bool Huffman::WriteCodeTable(Byte** ppByte) const
   ptr += len;
 
   BitStuffer2 bitStuffer2;
-  if (!bitStuffer2.EncodeSimple(&ptr, dataVec))    // code lengths, bit stuffed
+  if (!bitStuffer2.EncodeSimple(&ptr, dataVec, lerc2Version))    // code lengths, bit stuffed
     return false;
 
   if (!BitStuffCodes(&ptr, i0, i1))    // variable length codes, bit stuffed

--- a/src/LercLib/Huffman.h
+++ b/src/LercLib/Huffman.h
@@ -51,7 +51,7 @@ public:
   const std::vector<std::pair<unsigned short, unsigned int> >& GetCodes() const  { return m_codeTable; }
   bool SetCodes(const std::vector<std::pair<unsigned short, unsigned int> >& codeTable);
 
-  bool WriteCodeTable(Byte** ppByte) const;
+  bool WriteCodeTable(Byte** ppByte, int lerc2Version) const;
   bool ReadCodeTable(const Byte** ppByte, size_t& nBytesRemaining, int lerc2Version);
 
   bool BuildTreeFromCodes(int& numBitsLUT);


### PR DESCRIPTION
For the core Lerc2 codec, not the Lerc API, add a method to set the encode Lerc2 version, to allow for writing old Lerc2 versions. 