### PR TITLE
Set of fixes done during GDAL integration

### DIFF
--- a/src/LercLib/BitMask.cpp
+++ b/src/LercLib/BitMask.cpp
@@ -21,10 +21,11 @@ http://github.com/Esri/lerc/
 Contributors:  Thomas Maurer
 */
 
+#include "Defines.h"
 #include "BitMask.h"
 #include <cstring>
 
-using namespace LercNS;
+USING_NAMESPACE_LERC
 
 // -------------------------------------------------------------------------- ;
 

--- a/src/LercLib/BitMask.h
+++ b/src/LercLib/BitMask.h
@@ -24,8 +24,10 @@ Contributors:  Thomas Maurer
 #ifndef BITMASK_H
 #define BITMASK_H
 
-namespace LercNS
-{
+#include "Defines.h"
+
+NAMESPACE_LERC_START
+
   typedef unsigned char Byte;
 
   /** BitMask - Convenient and fast access to binary mask bits
@@ -71,6 +73,6 @@ namespace LercNS
     Byte*  m_pBits;
     int    m_nCols, m_nRows;
   };
-}    // namespace LercNS
+NAMESPACE_LERC_END
 
 #endif

--- a/src/LercLib/BitStuffer2.cpp
+++ b/src/LercLib/BitStuffer2.cpp
@@ -22,10 +22,11 @@ Contributors:  Thomas Maurer
 */
 
 #include <algorithm>
+#include "Defines.h"
 #include "BitStuffer2.h"
 
 using namespace std;
-using namespace LercNS;
+USING_NAMESPACE_LERC
 
 // -------------------------------------------------------------------------- ;
 

--- a/src/LercLib/Huffman.cpp
+++ b/src/LercLib/Huffman.cpp
@@ -23,11 +23,12 @@ Contributors:  Thomas Maurer
 
 #include <algorithm>
 #include <queue>
+#include "Defines.h"
 #include "Huffman.h"
 #include "BitStuffer2.h"
 
 using namespace std;
-using namespace LercNS;
+USING_NAMESPACE_LERC
 
 // -------------------------------------------------------------------------- ;
 

--- a/src/LercLib/Lerc.cpp
+++ b/src/LercLib/Lerc.cpp
@@ -23,7 +23,10 @@ Contributors:  Thomas Maurer
 
 #include "Lerc.h"
 #include "Lerc2.h"
+
+#ifdef HAVE_LERC1_DECODE
 #include "Lerc1Decode/CntZImage.h"
+#endif
 
 using namespace std;
 using namespace LercNS;
@@ -132,6 +135,8 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
     return ErrCode::Ok;
   }
 
+
+#ifdef HAVE_LERC1_DECODE
   // only if not Lerc2, try legacy Lerc1
   unsigned int numBytesHeader = CntZImage::computeNumBytesNeededToReadHeader();
   Byte* pByte = const_cast<Byte*>(pLercBlob);
@@ -201,6 +206,7 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
 
     return ErrCode::Ok;
   }
+#endif
 
   return ErrCode::Failed;
 }
@@ -337,7 +343,9 @@ ErrCode Lerc::DecodeTempl(T* pData, const Byte* pLercBlob, unsigned int numBytes
     return ErrCode::WrongParam;
 
   const Byte* pByte = pLercBlob;
+#ifdef HAVE_LERC1_DECODE
   Byte* pByte1 = const_cast<Byte*>(pLercBlob);
+#endif
   Lerc2::HeaderInfo hdInfo;
 
   if (Lerc2::GetHeaderInfo(pByte, numBytesBlob, hdInfo) && hdInfo.version >= 1)    // is Lerc2
@@ -357,7 +365,7 @@ ErrCode Lerc::DecodeTempl(T* pData, const Byte* pLercBlob, unsigned int numBytes
 
         T* arr = pData + nDim * nCols * nRows * iBand;
 
-        if (!lerc2.Decode(&pByte, nBytesRemaining, arr, (pBitMask && iBand == 0) ? pBitMask->Bits() : 0))
+        if (!lerc2.Decode(&pByte, nBytesRemaining, arr, (pBitMask && iBand == 0) ? pBitMask->Bits() : nullptr))
           return ErrCode::Failed;
       }
     }
@@ -365,6 +373,7 @@ ErrCode Lerc::DecodeTempl(T* pData, const Byte* pLercBlob, unsigned int numBytes
 
   else    // might be old Lerc1
   {
+#ifdef HAVE_LERC1_DECODE
     unsigned int numBytesHeader = CntZImage::computeNumBytesNeededToReadHeader();
     CntZImage zImg;
 
@@ -385,6 +394,9 @@ ErrCode Lerc::DecodeTempl(T* pData, const Byte* pLercBlob, unsigned int numBytes
       if (!Convert(zImg, arr, pBitMask))
         return ErrCode::Failed;
     }
+#else
+    return ErrCode::Failed;
+#endif
   }
 
   return ErrCode::Ok;
@@ -393,6 +405,7 @@ ErrCode Lerc::DecodeTempl(T* pData, const Byte* pLercBlob, unsigned int numBytes
 // -------------------------------------------------------------------------- ;
 // -------------------------------------------------------------------------- ;
 
+#ifdef HAVE_LERC1_DECODE
 template<class T>
 bool Lerc::Convert(const CntZImage& zImg, T* arr, BitMask* pBitMask)
 {
@@ -426,6 +439,7 @@ bool Lerc::Convert(const CntZImage& zImg, T* arr, BitMask* pBitMask)
 
   return true;
 }
+#endif
 
 // -------------------------------------------------------------------------- ;
 

--- a/src/LercLib/Lerc.cpp
+++ b/src/LercLib/Lerc.cpp
@@ -21,6 +21,7 @@ http://github.com/Esri/lerc/
 Contributors:  Thomas Maurer
 */
 
+#include "Defines.h"
 #include "Lerc.h"
 #include "Lerc2.h"
 
@@ -29,7 +30,7 @@ Contributors:  Thomas Maurer
 #endif
 
 using namespace std;
-using namespace LercNS;
+USING_NAMESPACE_LERC
 
 // -------------------------------------------------------------------------- ;
 

--- a/src/LercLib/Lerc.h
+++ b/src/LercLib/Lerc.h
@@ -38,8 +38,8 @@ NAMESPACE_LERC_START
   class Lerc
   {
   public:
-    Lerc() {};
-    ~Lerc() {};
+    Lerc() {}
+    ~Lerc() {}
 
     // data types supported by Lerc
     enum DataType { DT_Char, DT_Byte, DT_Short, DT_UShort, DT_Int, DT_UInt, DT_Float, DT_Double, DT_Undefined };

--- a/src/LercLib/Lerc.h
+++ b/src/LercLib/Lerc.h
@@ -31,7 +31,9 @@ Contributors:  Thomas Maurer
 
 namespace LercNS
 {
+#ifdef HAVE_LERC1_DECODE
   class CntZImage;
+#endif
 
   class Lerc
   {
@@ -178,7 +180,9 @@ namespace LercNS
       BitMask* pBitMask);              // gets filled if not 0, even if all valid
 
   private:
+#ifdef HAVE_LERC1_DECODE
     template<class T> static bool Convert(const CntZImage& zImg, T* arr, BitMask* pBitMask);
+#endif
     template<class T> static ErrCode ConvertToDoubleTempl(const T* pDataIn, size_t nDataValues, double* pDataOut);
   };
 }    // namespace LercNS

--- a/src/LercLib/Lerc.h
+++ b/src/LercLib/Lerc.h
@@ -29,8 +29,8 @@ Contributors:  Thomas Maurer
 #include "BitMask.h"
 #include "Lerc2.h"
 
-namespace LercNS
-{
+NAMESPACE_LERC_START
+
 #ifdef HAVE_LERC1_DECODE
   class CntZImage;
 #endif
@@ -185,4 +185,4 @@ namespace LercNS
 #endif
     template<class T> static ErrCode ConvertToDoubleTempl(const T* pDataIn, size_t nDataValues, double* pDataOut);
   };
-}    // namespace LercNS
+NAMESPACE_LERC_END

--- a/src/LercLib/Lerc2.cpp
+++ b/src/LercLib/Lerc2.cpp
@@ -22,9 +22,10 @@ Contributors:   Thomas Maurer
                 Lucian Plesea (provided checksum code)
 */
 
+#include "Defines.h"
 #include "Lerc2.h"
 
-using namespace LercNS;
+USING_NAMESPACE_LERC
 using namespace std;
 
 // -------------------------------------------------------------------------- ;

--- a/src/LercLib/Lerc2.h
+++ b/src/LercLib/Lerc2.h
@@ -2016,7 +2016,7 @@ bool Lerc2::DecodeHuffman(const Byte** ppByte, size_t& nBytesRemainingInOut, T* 
 // -------------------------------------------------------------------------- ;
 
 template<class T>
-bool Lerc2::WriteMinMaxRanges(const T* data, Byte** ppByte) const
+bool Lerc2::WriteMinMaxRanges(const T* /*data*/, Byte** ppByte) const
 {
   if (!ppByte || !(*ppByte))
     return false;
@@ -2048,7 +2048,7 @@ bool Lerc2::WriteMinMaxRanges(const T* data, Byte** ppByte) const
 // -------------------------------------------------------------------------- ;
 
 template<class T>
-bool Lerc2::ReadMinMaxRanges(const Byte** ppByte, size_t& nBytesRemaining, const T* data)
+bool Lerc2::ReadMinMaxRanges(const Byte** ppByte, size_t& nBytesRemaining, const T* /*data*/)
 {
   if (!ppByte || !(*ppByte))
     return false;

--- a/src/LercLib/Lerc2.h
+++ b/src/LercLib/Lerc2.h
@@ -29,6 +29,7 @@ Contributors:  Thomas Maurer
 #include <cmath>
 #include <string>
 #include <typeinfo>
+#include "Defines.h"
 #include "BitMask.h"
 #include "BitStuffer2.h"
 #include "Huffman.h"

--- a/src/LercLib/Lerc_c_api_impl.cpp
+++ b/src/LercLib/Lerc_c_api_impl.cpp
@@ -46,7 +46,7 @@ lerc_status lerc_computeCompressedSize(const void* pData, unsigned int dataType,
         if (!pValidBytes[k])
           bitMask.SetInvalid(k);
   }
-  const BitMask* pBitMask = pValidBytes ? &bitMask : 0;
+  const BitMask* pBitMask = pValidBytes ? &bitMask : nullptr;
 
   Lerc::DataType dt = (Lerc::DataType)dataType;
   return (lerc_status)Lerc::ComputeCompressedSize(pData, dt, nDim, nCols, nRows, nBands, pBitMask, maxZErr, *numBytes);
@@ -72,7 +72,7 @@ lerc_status lerc_encode(const void* pData, unsigned int dataType, int nDim, int 
         if (!pValidBytes[k])
           bitMask.SetInvalid(k);
   }
-  const BitMask* pBitMask = pValidBytes ? &bitMask : 0;
+  const BitMask* pBitMask = pValidBytes ? &bitMask : nullptr;
 
   Lerc::DataType dt = (Lerc::DataType)dataType;
   return (lerc_status)Lerc::Encode(pData, dt, nDim, nCols, nRows, nBands, pBitMask, maxZErr, pOutBuffer, outBufferSize, *nBytesWritten);
@@ -148,7 +148,7 @@ lerc_status lerc_decode(const unsigned char* pLercBlob, unsigned int blobSize,
     bitMask.SetSize(nCols, nRows);
     bitMask.SetAllInvalid();
   }
-  BitMask* pBitMask = pValidBytes ? &bitMask : 0;
+  BitMask* pBitMask = pValidBytes ? &bitMask : nullptr;
 
   Lerc::DataType dt = (Lerc::DataType)dataType;
 
@@ -189,7 +189,7 @@ lerc_status lerc_decodeToDouble(const unsigned char* pLercBlob, unsigned int blo
     bitMask.SetSize(nCols, nRows);
     bitMask.SetAllInvalid();
   }
-  BitMask* pBitMask = pValidBytes ? &bitMask : 0;
+  BitMask* pBitMask = pValidBytes ? &bitMask : nullptr;
 
   if (dt == Lerc::DT_Double)
   {

--- a/src/LercLib/Lerc_c_api_impl.cpp
+++ b/src/LercLib/Lerc_c_api_impl.cpp
@@ -21,11 +21,12 @@ http://github.com/Esri/lerc/
 Contributors:  Thomas Maurer
 */
 
+#include "Defines.h"
 #include "Lerc_c_api.h"
 #include "Lerc_types.h"
 #include "Lerc.h"
 
-using namespace LercNS;
+USING_NAMESPACE_LERC
 
 // -------------------------------------------------------------------------- ;
 

--- a/src/LercLib/Lerc_types.h
+++ b/src/LercLib/Lerc_types.h
@@ -6,8 +6,9 @@
 // This header file tells you what these integers mean. 
 // These enum's may grow in the future. More values can be added. 
 
-namespace LercNS
-{
+#include "Defines.h"
+
+NAMESPACE_LERC_START
   enum class ErrCode : int
   {
     Ok = 0,
@@ -47,5 +48,4 @@ namespace LercNS
     maxZErrUsed
   };
 
-}    // namespace
-
+NAMESPACE_LERC_END

--- a/src/LercLib/RLE.cpp
+++ b/src/LercLib/RLE.cpp
@@ -21,10 +21,11 @@ http://github.com/Esri/lerc/
 Contributors:  Thomas Maurer
 */
 
+#include "Defines.h"
 #include "RLE.h"
 #include <cstring>
 
-using namespace LercNS;
+USING_NAMESPACE_LERC
 
 // -------------------------------------------------------------------------- ;
 


### PR DESCRIPTION
They should be OK for upstream inclusion. You may need to define -DHAVE_LERC1_DECODE to get exact same behaviour as currently (this is not defined in GDAL since I didn't importe the Lerc1Decode/ subdirectory)