### PR TITLE
RLE::decompress(): avoid index out-of-bound error on corrupted file.

### DIFF
--- a/src/LercLib/RLE.cpp
+++ b/src/LercLib/RLE.cpp
@@ -307,8 +307,8 @@ bool RLE::decompress(const Byte* arrRLE, size_t nBytesRemaining, Byte* arr, size
   short cnt = readCount(&srcPtr);
   while (cnt != -32768)
   {
-    size_t i = cnt < 0 ? -cnt : cnt;
-    size_t m = cnt < 0 ? 1 : i;
+    size_t i = cnt <= 0 ? -cnt : cnt;
+    size_t m = cnt <= 0 ? 1 : i;
 
     if (nBytesRemaining < m + 2 || arrIdx + i > arrSize)
       return false;


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9282. Credit to OSS Fuzz