### PR TITLE
BitStuffer2::Decode(): add check for numBits == 0 in LUT case to avoid undefined behaviour

### DIFF
--- a/src/LercLib/BitStuffer2.cpp
+++ b/src/LercLib/BitStuffer2.cpp
@@ -193,6 +193,8 @@ bool BitStuffer2::Decode(const Byte** ppByte, size_t& nBytesRemaining, vector<un
   }
   else
   {
+    if (numBits == 0)
+      return false;
     if (nBytesRemaining < 1)
       return false;
 


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9284 . Credit to OSS Fuzz

when numBits == 0, a right shift by 32 bits happen in BitUnsStuff,
which is undefined behaviour per the C/C++ standards, and non sensical.
```
BitStuffer2.cpp:374:21: runtime error: shift exponent 32 is too large for 32-bit type 'unsigned int'
	#0 0x17b8c35 in GDAL_LercNS::BitStuffer2::BitUnStuff_Before_Lerc2v3(unsigned char const**, unsigned long&, std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >&, unsigned int, int) gdal/gdal/third_party/LercLib/BitStuffer2.cpp:374:21
	#1 0x17b7e41 in GDAL_LercNS::BitStuffer2::Decode(unsigned char const**, unsigned long&, std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >&, int) const gdal/gdal/third_party/LercLib/BitStuffer2.cpp:213:12
	#2 0x13c5481 in bool GDAL_LercNS::Lerc2::ReadTile<double>(unsigned char const**, unsigned long&, double*, int, int, int, int, int, std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >&) const gdal/gdal/third_party/LercLib/Lerc2.h:1283:26
```