### PR TITLE
Lerc::GetLercInfo(): fix integer overflow

### DIFF
--- a/src/LercLib/Lerc.cpp
+++ b/src/LercLib/Lerc.cpp
@@ -25,6 +25,8 @@ Contributors:  Thomas Maurer
 #include "Lerc.h"
 #include "Lerc2.h"
 
+#include <limits>
+
 #ifdef HAVE_LERC1_DECODE
 #include "Lerc1Decode/CntZImage.h"
 #endif
@@ -121,6 +123,9 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
       {
         return ErrCode::Failed;
       }
+
+      if( lercInfo.blobSize > std::numeric_limits<int>::max() - hdInfo.blobSize )
+        return ErrCode::Failed;
 
       lercInfo.blobSize += hdInfo.blobSize;
 


### PR DESCRIPTION
If Lerc2::GetHeaderInfo() on a band > 1 returns a huge blob size,
we can overflow the total header blob size while adding it to the
existing size, leading to a negative value and later overflows.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=11016
Credit to OSS-Fuzz