### PR TITLE
prep for npm v2.0.0 release

### DIFF
--- a/OtherLanguages/js/.npmignore
+++ b/OtherLanguages/js/.npmignore
@@ -1,4 +1,0 @@
-node_modules
-
-index.htm
-README.hbs

--- a/OtherLanguages/js/CHANGELOG.md
+++ b/OtherLanguages/js/CHANGELOG.md
@@ -13,9 +13,6 @@ The decoder is in sync with ArcMap 10.7 and ArcGIS Pro 2.3. LERC encoded binary 
 
 ### Added
 * Extend from one value per pixel to nDim values per pixel.
-* Add new lossy compression option for integer types (aiming at noisy 16 bit satellite images). Cuts off noisy bit planes.
-* Add more rigorous checking against buffer overrun while decoding. (This concept taken from the MRF / gdal repo.)
-* Enable encode / write former versions 2.3 and 2.2. This is to allow MRF / gdal to make their Lerc2 calls into this Lerc lib.
 
 ### Changed
 * Upgrade Lerc codec to new version Lerc 2.4.

--- a/OtherLanguages/js/CHANGELOG.md
+++ b/OtherLanguages/js/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased][HEAD]
+
+## [2.0.0] - 2018-11-06
+
+The decoder is in sync with ArcMap 10.7 and ArcGIS Pro 2.3. LERC encoded binary blobs from any previous version of ArcMap or ArcGIS Pro can also be read / decoded.
+
+### Added
+* Extend from one value per pixel to nDim values per pixel.
+* Add new lossy compression option for integer types (aiming at noisy 16 bit satellite images). Cuts off noisy bit planes.
+* Add more rigorous checking against buffer overrun while decoding. (This concept taken from the MRF / gdal repo.)
+* Enable encode / write former versions 2.3 and 2.2. This is to allow MRF / gdal to make their Lerc2 calls into this Lerc lib.
+
+### Changed
+* Upgrade Lerc codec to new version Lerc 2.4.
+
 ## 1.0.1 - 2017-02-18
 
 ### Fixed
@@ -13,9 +28,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.0 - 2016-11-30
 
-- This LERC API JavaScript decoder is in sync with ArcMap 10.5 and ArcGIS Pro 1.4. LERC encoded binary blobs from any previous version of ArcMap or ArcGIS Pro can be read / decoded as well.
+This LERC API JavaScript decoder is in sync with ArcMap 10.5 and ArcGIS Pro 1.4. LERC encoded binary blobs from any previous version of ArcMap or ArcGIS Pro can be read / decoded as well.
 
 ### What will trigger a major version change
 
 - A change to this LERC API that is not backwards compatible and requires users to update / change their code in order to use an upgraded .dll or .so file.
 - A change to the LERC bitstream that is not backwards compatible and requires users to upgrade their LERC encoder and / or decoder.
+
+[2.0.0]: https://github.com/Esri/lerc/compare/v1.0.1...v2.0 "v2.0"
+[HEAD]: https://github.com/Esri/lerc/compare/v2.0...HEAD "Unreleased Changes"

--- a/OtherLanguages/js/LercDecode.js
+++ b/OtherLanguages/js/LercDecode.js
@@ -1,6 +1,6 @@
 /* jshint forin: false, bitwise: false */
 /*
-Copyright 2015 Esri
+Copyright 2015-2018 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ Contributors:  Johannes Schmid, (LERC v1)
                Wenxue Ju (LERC v1, v2.x)
 */
 
-/* Copyright 2015 Esri. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 @preserve */
+/* Copyright 2015-2018 Esri. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 @preserve */
 
 /**
  * a module for decoding LERC blobs
@@ -1562,14 +1562,14 @@ Contributors:  Johannes Schmid, (LERC v1)
                   data.pixels.resultPixels[nStart + k] = val;
                 }
               }
-            }  
+            }
           }
           else {
             for (k = 0; k < numPixels; k++) {
               if (mask[k]) {
                 data.pixels.resultPixels[k] = val;
               }
-            }         
+            }
           }
         }
         else {
@@ -2089,7 +2089,7 @@ Contributors:  Johannes Schmid, (LERC v1)
         }
         decodedPixelBlock.maskData = maskData;
       }
-      
+
       return decodedPixelBlock;
     }
   };

--- a/OtherLanguages/js/README.hbs
+++ b/OtherLanguages/js/README.hbs
@@ -10,7 +10,7 @@
 ## Browser
 
 ```html
-<script type="text/javascript" src="./LercDecode.js"></script>
+<script type="text/javascript" src="https://unpkg.com/lerc"></script>
 ```
 ```js
 Lerc.decode(xhrResponse, {
@@ -22,28 +22,18 @@ Lerc.decode(xhrResponse, {
 ## Node
 
 ```js
-npm install 'lerc'
+npm install lerc && npm install node-fetch
 ```
 ```js
-var http = require('http');
-var Lerc = require('lerc');
+const fetch = require('node-fetch');
+const Lerc = require('lerc');
 
-http.get('http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer/tile/0/0/0', function (res) {
-  var data = [];
-  res.on('data', function (chunk) {
-    // append each chunk to a list of buffer objects
-    data.push(chunk);
-  })
-  res.on('end', function () {
-    // turn the list into one large Buffer
-    data = Buffer.concat(data);
-    // because the decoder expects an ArrayBuffer
-    var image = Lerc.decode(data.buffer);
-    console.log("width of output is: " + image.width);
-  })
-});
-
-// more info: https://github.com/dcodeIO/protobuf.js/wiki/How-to-read-binary-data-in-the-browser-or-under-node.js%3F
+fetch('http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer/tile/0/0/0')
+  .then(response => response.arrayBuffer())
+  .then(body => {
+    const image = Lerc.decode(body);
+    image.width // 257
+  });
 ```
 
 ## API Reference
@@ -53,7 +43,7 @@ http.get('http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Te
 
 ## Licensing
 
-Copyright 2017 Esri
+Copyright &copy; 2017-2018 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -67,6 +57,3 @@ See the License for the specific language governing permissions and limitations 
 A local copy of the license and additional notices are located with the source distribution at:
 
 http://github.com/Esri/lerc/
-
-[](Esri Tags: raster, image, encoding, encoded, decoding, decoded, compression, codec, lerc)
-[](Esri Language: JS, JavaScript, Python)

--- a/OtherLanguages/js/README.md
+++ b/OtherLanguages/js/README.md
@@ -10,7 +10,7 @@
 ## Browser
 
 ```html
-<script type="text/javascript" src="./LercDecode.js"></script>
+<script type="text/javascript" src="https://unpkg.com/lerc"></script>
 ```
 ```js
 Lerc.decode(xhrResponse, {
@@ -22,28 +22,18 @@ Lerc.decode(xhrResponse, {
 ## Node
 
 ```js
-npm install 'lerc'
+npm install lerc && npm install node-fetch
 ```
 ```js
-var http = require('http');
-var Lerc = require('lerc');
+const fetch = require('node-fetch');
+const Lerc = require('lerc');
 
-http.get('http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer/tile/0/0/0', function (res) {
-  var data = [];
-  res.on('data', function (chunk) {
-    // append each chunk to a list of buffer objects
-    data.push(chunk);
-  })
-  res.on('end', function () {
-    // turn the list into one large Buffer
-    data = Buffer.concat(data);
-    // because the decoder expects an ArrayBuffer
-    var image = Lerc.decode(data.buffer);
-    console.log("width of output is: " + image.width);
-  })
-});
-
-// more info: https://github.com/dcodeIO/protobuf.js/wiki/How-to-read-binary-data-in-the-browser-or-under-node.js%3F
+fetch('http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer/tile/0/0/0')
+  .then(response => response.arrayBuffer())
+  .then(body => {
+    const image = Lerc.decode(body);
+    image.width // 257
+  });
 ```
 
 ## API Reference
@@ -68,7 +58,7 @@ A wrapper for decoding both LERC1 and LERC2 byte streams capable of handling mul
 | [options.pixelType] | <code>string</code> | (LERC1 only) Default value is F32. Valid pixel types for input are U8/S8/S16/U16/S32/U32/F32. |
 | [options.noDataValue] | <code>number</code> | (LERC1 only). It is recommended to use the returned mask instead of setting this value. |
 
-**Result Object**
+**Result Object Properties**
 
 | Name | Type | Description |
 | --- | --- | --- |
@@ -83,7 +73,7 @@ A wrapper for decoding both LERC1 and LERC2 byte streams capable of handling mul
 
 ## Licensing
 
-Copyright 2017-2018 Esri
+Copyright &copy; 2017-2018 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/OtherLanguages/js/package.json
+++ b/OtherLanguages/js/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/esri/lerc/issues"
   },
   "description": "Rapid decoding of Lerc compressed raster data for any standard pixel type.",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "author": "Esri <dev_tools@esri.com> (http://developers.arcgis.com)",
   "contributors": [
     "Johannes Schmid",
@@ -18,6 +18,7 @@
     "jshint": "^2.9.4",
     "uglify-js": "^2.7.5"
   },
+  "files": [ "LercDecode.js" ],
   "homepage": "https://github.com/Esri/lerc",
   "license": "Apache-2.0",
   "main": "LercDecode.js",


### PR DESCRIPTION
* update JS changelog
  * add links to diff individual tags
* simplify Node.js code snippet
* bump copyright ranges

resolves #76