### PR TITLE
lint js and include minified file in npm registry

### DIFF
--- a/OtherLanguages/js/LercDecode.js
+++ b/OtherLanguages/js/LercDecode.js
@@ -1341,7 +1341,7 @@ Contributors:  Johannes Schmid, (LERC v1)
               stuffedData = new Uint32Array(arrayBuf);
               data.ptr += dataBytes;
               if (fileVersion >= 3) {
-                if (offset == null) {
+                if (offset === null) {
                   BitStuffer.originalUnstuff2(stuffedData, blockDataBuffer, bitsPerPixel, numElements);
                 }
                 else {
@@ -1349,7 +1349,7 @@ Contributors:  Johannes Schmid, (LERC v1)
                 }
               }
               else {
-                if (offset == null) {
+                if (offset === null) {
                   BitStuffer.originalUnstuff(stuffedData, blockDataBuffer, bitsPerPixel, numElements);
                 }
                 else {
@@ -1652,7 +1652,7 @@ Contributors:  Johannes Schmid, (LERC v1)
       },
 
       isValidPixelValue: function(t, val) {
-        if (val == null) {
+        if (val === null) {
           return false;
         }
         var isValid;

--- a/OtherLanguages/js/package.json
+++ b/OtherLanguages/js/package.json
@@ -18,7 +18,10 @@
     "jshint": "^2.9.4",
     "uglify-js": "^2.7.5"
   },
-  "files": [ "LercDecode.js" ],
+  "files": [
+    "LercDecode.js",
+    "LercDecode.min.js"
+  ],
   "homepage": "https://github.com/Esri/lerc",
   "license": "Apache-2.0",
   "main": "LercDecode.js",


### PR DESCRIPTION
`v2.0.0` has been published to [npm](https://www.npmjs.com/package/lerc).

https://unpkg.com/lerc@2.0.0/

i noticed a few linter nags while i was publishing. i'm also proposing a small tweak to ensure that we push up a minified version of the JS source going forward.