### PR TITLE
Update NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -9,8 +9,7 @@ Assignee: Esri.
 Assignors/Inventors: Maurer, Thomas (Redlands, CA); Gao, Peng (Redlands, CA); Becker, Peter (Redlands, CA).
 
 The right to practice this patent is hereby granted under the Apache V2.0 License Agreement,
-Clause 3 - Grant of Patent License for the following fields of use:
-GIS, terrestrial and extra-terrestrial mapping, and other related earth sciences applications.
+Clause 3 - Grant of Patent License.
 
 The license is available at
 http://github.com/Esri/lerc/


### PR DESCRIPTION
Update the NOTICE file to remove any restrictions on domains of practice.  Esri will now allow the patent to be practiced without domain restriction.