### PR TITLE
Disable performance optimization of CntzImage::read

### DIFF
--- a/Lerc/src/Lerc1Decode/CntZImage.cpp
+++ b/Lerc/src/Lerc1Decode/CntZImage.cpp
@@ -68,7 +68,7 @@ unsigned int CntZImage::computeNumBytesNeededToReadHeader()
 
 // -------------------------------------------------------------------------- ;
 
-#if defined(RTC_COCOA_OSX)
+#if defined(RTC_COCOA_OSX) && !defined(DEBUG)
 // release builds of RTC use -O3 which causes this function 
 // to be optimized away in some cases, resulting in terrain 
 // data reporting as 0 or empty
@@ -78,7 +78,7 @@ unsigned int CntZImage::computeNumBytesNeededToReadHeader()
 #else
 #pragma GCC error "Investigate whether this workaround is still necessary..."
 #endif // !__clang_major__==10 && __clang_minor__==0 && __clang_patchlevel__==0
-#endif // defined(RTC_COCOA_OSX)
+#endif // defined(RTC_COCOA_OSX) && !defined(DEBUG)
 bool CntZImage::read(Byte** ppByte, bool& hasInvalidData, double maxZError, bool onlyHeader, bool onlyZPart)
 {
   if (!ppByte || !*ppByte)

--- a/Lerc/src/Lerc1Decode/CntZImage.cpp
+++ b/Lerc/src/Lerc1Decode/CntZImage.cpp
@@ -74,7 +74,7 @@ unsigned int CntZImage::computeNumBytesNeededToReadHeader()
 // data reporting as 0 or empty
 // See https://devtopia.esri.com/runtimecore/c_api/issues/12246
 #if __clang_major__==10 && __clang_minor__==0 && __clang_patchlevel__==0
-[[clang::optnone]]
+__attribute__((minsize)) // Perf opt causes the error, size does not
 #else
 #pragma GCC error "Investigate whether this workaround is still necessary..."
 #endif // !__clang_major__==10 && __clang_minor__==0 && __clang_patchlevel__==0

--- a/Lerc/src/Lerc1Decode/CntZImage.cpp
+++ b/Lerc/src/Lerc1Decode/CntZImage.cpp
@@ -68,6 +68,17 @@ unsigned int CntZImage::computeNumBytesNeededToReadHeader()
 
 // -------------------------------------------------------------------------- ;
 
+#if defined(RTC_COCOA_OSX)
+// release builds of RTC use -O3 which causes this function 
+// to be optimized away in some cases, resulting in terrain 
+// data reporting as 0 or empty
+// See https://devtopia.esri.com/runtimecore/c_api/issues/12246
+#if __clang_major__==10 && __clang_minor__==0 && __clang_patchlevel__==0
+[[clang::optnone]]
+#else
+#pragma GCC error "Investigate whether this workaround is still necessary..."
+#endif // !__clang_major__==10 && __clang_minor__==0 && __clang_patchlevel__==0
+#endif // defined(RTC_COCOA_OSX)
 bool CntZImage::read(Byte** ppByte, bool& hasInvalidData, double maxZError, bool onlyHeader, bool onlyZPart)
 {
   if (!ppByte || !*ppByte)


### PR DESCRIPTION
This function was being optimized to always return `false` 
in the runtimecore branch leading to failures in our surface 
tests suite. Preferring size optimization over perf for only this 
function restores the expected behavior for rtc release 
builds on macOS.

https://devtopia.esri.com/runtimecore/c_api/issues/12246

3rd party build: ~http://runtime-test.esri.com:8080/job/3rdparty_vtest_interface/263/downstreambuildview/~
http://runtime-test.esri.com:8080/job/3rdparty_vtest_interface/270/downstreambuildview/ (release)
http://runtime-test.esri.com:8080/job/3rdparty_vtest_interface/271/downstreambuildview/ (debug)

RTC build+test: ~http://runtime-test.esri.com:8080/job/vtest_interface/1555/downstreambuildview/~
http://runtime-test.esri.com:8080/job/vtest_interface/1599/downstreambuildview/ (release)
http://runtime-test.esri.com:8080/job/vtest_interface/1601/downstreambuildview/ (debug)