### PR TITLE
Catch illegal memory allocation on 32 bit builds

### DIFF
--- a/src/LercLib/BitStuffer2.cpp
+++ b/src/LercLib/BitStuffer2.cpp
@@ -355,7 +355,7 @@ bool BitStuffer2::BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesR
   {
     dataVec.resize(numElements, 0);    // init with 0
   }
-  catch( const std::bad_alloc& )
+  catch( const std::exception& )
   {
     return false;
   }
@@ -483,7 +483,7 @@ bool BitStuffer2::BitUnStuff(const Byte** ppByte, size_t& nBytesRemaining, vecto
   {
     dataVec.resize(numElements);
   }
-  catch( const std::bad_alloc& )
+  catch( const std::exception& )
   {
     return false;
   }
@@ -495,7 +495,7 @@ bool BitStuffer2::BitUnStuff(const Byte** ppByte, size_t& nBytesRemaining, vecto
   {
     m_tmpBitStuffVec.resize(numUInts);
   }
-  catch( const std::bad_alloc& )
+  catch( const std::exception& )
   {
     return false;
   }

--- a/src/LercLib/Huffman.cpp
+++ b/src/LercLib/Huffman.cpp
@@ -227,7 +227,7 @@ bool Huffman::ReadCodeTable(const Byte** ppByte, size_t& nBytesRemainingInOut, i
     nBytesRemainingInOut = nBytesRemaining;
     return true;
   }
-  catch (std::bad_alloc&)
+  catch (std::exception&)
   {
     return false;
   }


### PR DESCRIPTION
Replace a few catch of bad_alloc by exception to handle the case
of 32 bit trying to allocate more than 4GB of memory and thus
throwing a length_error exception. Found by OSS Fuzz