### PR TITLE
BitStuffer2: avoid big memory allocation attempts on corrupted files

### DIFF
--- a/src/LercLib/BitStuffer2.cpp
+++ b/src/LercLib/BitStuffer2.cpp
@@ -22,6 +22,7 @@ Contributors:  Thomas Maurer
 */
 
 #include <algorithm>
+#include <limits>
 #include "Defines.h"
 #include "BitStuffer2.h"
 
@@ -351,6 +352,15 @@ void BitStuffer2::BitStuff_Before_Lerc2v3(Byte** ppByte, const vector<unsigned i
 bool BitStuffer2::BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesRemaining, 
     vector<unsigned int>& dataVec, unsigned int numElements, int numBits)
 {
+  if (numBits >= 32)
+    return false;
+  unsigned int numUInts = (unsigned int)((unsigned long long)numElements * numBits + 31) / 32;
+  unsigned int numBytes = numUInts * sizeof(unsigned int);
+  unsigned int* arr = (unsigned int*)(*ppByte);
+
+  if (nBytesRemaining < numBytes)
+    return false;
+
   try
   {
     dataVec.resize(numElements, 0);    // init with 0
@@ -359,13 +369,6 @@ bool BitStuffer2::BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesR
   {
     return false;
   }
-
-  unsigned int numUInts = (numElements * numBits + 31) / 32;
-  unsigned int numBytes = numUInts * sizeof(unsigned int);
-  unsigned int* arr = (unsigned int*)(*ppByte);
-
-  if (nBytesRemaining < numBytes)
-    return false;
 
   unsigned int* srcPtr = arr;
   srcPtr += numUInts;
@@ -478,6 +481,16 @@ bool BitStuffer2::BitUnStuff(const Byte** ppByte, size_t& nBytesRemaining, vecto
 {
   if (numElements == 0)
     return false;
+  if (numBits >= 32)
+    return false;
+  unsigned int numUInts = (unsigned int)((unsigned long long)numElements * numBits + 31) / 32;
+  unsigned int numBytes = numUInts * sizeof(unsigned int);
+
+  // copy the bytes from the incoming byte stream
+  int numBytesUsed = numBytes - NumTailBytesNotNeeded(numElements, numBits);
+
+  if (nBytesRemaining < (size_t)numBytesUsed)
+    return false;
 
   try
   {
@@ -487,9 +500,6 @@ bool BitStuffer2::BitUnStuff(const Byte** ppByte, size_t& nBytesRemaining, vecto
   {
     return false;
   }
-
-  unsigned int numUInts = (numElements * numBits + 31) / 32;
-  unsigned int numBytes = numUInts * sizeof(unsigned int);
 
   try
   {
@@ -502,11 +512,7 @@ bool BitStuffer2::BitUnStuff(const Byte** ppByte, size_t& nBytesRemaining, vecto
 
   m_tmpBitStuffVec[numUInts - 1] = 0;    // set last uint to 0
 
-  // copy the bytes from the incoming byte stream
-  int numBytesUsed = numBytes - NumTailBytesNotNeeded(numElements, numBits);
-
-  if (nBytesRemaining < (size_t)numBytesUsed || !memcpy(&m_tmpBitStuffVec[0], *ppByte, numBytesUsed))
-    return false;
+  memcpy(&m_tmpBitStuffVec[0], *ppByte, numBytesUsed);
 
   // do the un-stuffing
   unsigned int* srcPtr = &m_tmpBitStuffVec[0];


### PR DESCRIPTION
Move some validation checks earlier, before attempting potentially
big memory allocation attempts.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=16595
Credit to OSS Fuzz