### PR TITLE
Avoid potential access to uninitialized memory regarding bit mask.

### DIFF
--- a/src/LercLib/BitMask.h
+++ b/src/LercLib/BitMask.h
@@ -36,7 +36,7 @@ class BitMask
 {
 public:
   BitMask() : m_pBits(nullptr), m_nCols(0), m_nRows(0)  {}
-  BitMask(int nCols, int nRows) : m_pBits(nullptr)      { SetSize(nCols, nRows); }
+  BitMask(int nCols, int nRows) : m_pBits(nullptr), m_nCols(0), m_nRows(0) { SetSize(nCols, nRows); }
   BitMask(const BitMask& src);
   virtual ~BitMask()                        { Clear(); }
 

--- a/src/LercLib/Lerc2.cpp
+++ b/src/LercLib/Lerc2.cpp
@@ -699,8 +699,16 @@ bool Lerc2::ReadMask(const Byte** ppByte, size_t& nBytesRemainingInOut)
   ptr += sizeof(int);
   nBytesRemaining -= sizeof(int);
 
-  if ((numValid == 0 || numValid == w * h) && (numBytesMask != 0))
-    return false;
+  if (numValid == 0 || numValid == w * h)
+  {
+    if (numBytesMask != 0)
+      return false;
+  }
+  else
+  {
+    if (numBytesMask <= 0)
+      return false;
+  }
 
   if (!m_bitMask.SetSize(w, h))
     return false;


### PR DESCRIPTION
Triggered by https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19158 ,
although I could not replicate exactly the issue raised by the fuzzer.