### PR TITLE
Lerc2::ReadHeader(): fix Invalid-enum-value undefined behaviour on corrupted files

### DIFF
--- a/src/LercLib/Lerc2.cpp
+++ b/src/LercLib/Lerc2.cpp
@@ -623,7 +623,10 @@ bool Lerc2::ReadHeader(const Byte** ppByte, size_t& nBytesRemainingInOut, struct
   hd.numValidPixel  = intVec[i++];
   hd.microBlockSize = intVec[i++];
   hd.blobSize       = intVec[i++];
-  hd.dt             = static_cast<DataType>(intVec[i++]);
+  const int dt      = intVec[i++];
+  if (dt < DT_Char || dt > DT_Double)
+    return false;
+  hd.dt             = static_cast<DataType>(dt);
 
   hd.maxZError      = dblVec[0];
   hd.zMin           = dblVec[1];


### PR DESCRIPTION
Raised in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19355

Fixes a non compliance w.r.t C++ standard:
https://wiki.sei.cmu.edu/confluence/display/cplusplus/INT50-CPP.+Do+not+cast+to+an+out-of-range+enumeration+value