### PR TITLE
Lerc2::GetDataTypeUsed(): fix Invalid-enum-value undefined behaviour on corrupted files

### DIFF
--- a/src/LercLib/Lerc2.cpp
+++ b/src/LercLib/Lerc2.cpp
@@ -1828,6 +1828,8 @@ bool Lerc2::ReadTile(const Byte** ppByte, size_t& nBytesRemainingInOut, T* data,
   {
     // read z's as int arr bit stuffed
     DataType dtUsed = GetDataTypeUsed((bDiffEnc && hd.dt < DT_Float) ? DT_Int : hd.dt, bits67);
+    if (dtUsed == DT_Undefined)
+      return false;
     size_t n = GetDataTypeSize(dtUsed);
     if (nBytesRemaining < n)
       return false;

--- a/src/LercLib/Lerc2.h
+++ b/src/LercLib/Lerc2.h
@@ -224,6 +224,8 @@ private:
 
   static DataType GetDataTypeUsed(DataType dt, int reducedTypeCode);
 
+  static DataType ValidateDataType(int dt);
+
   static bool WriteVariableDataType(Byte** ppByte, double z, DataType dtUsed);
 
   static double ReadVariableDataType(const Byte** ppByte, DataType dtUsed);
@@ -487,17 +489,26 @@ inline int Lerc2::ReduceDataType(T z, DataType dt, DataType& dtReduced)
 
 // -------------------------------------------------------------------------- ;
 
+inline Lerc2::DataType Lerc2::ValidateDataType(int dt)
+{
+  if( dt >= DT_Char && dt <= DT_Double )
+    return static_cast<DataType>(dt);
+  return DT_Undefined;
+}
+
+// -------------------------------------------------------------------------- ;
+
 inline
 Lerc2::DataType Lerc2::GetDataTypeUsed(DataType dt, int tc)
 {
   switch (dt)
   {
     case DT_Short:
-    case DT_Int:     return (DataType)(dt - tc);
+    case DT_Int:     return ValidateDataType(dt - tc);
     case DT_UShort:
-    case DT_UInt:    return (DataType)(dt - 2 * tc);
+    case DT_UInt:    return ValidateDataType(dt - 2 * tc);
     case DT_Float:   return tc == 0 ? dt : (tc == 1 ? DT_Short : DT_Byte);
-    case DT_Double:  return tc == 0 ? dt : (DataType)(dt - 2 * tc + 1);
+    case DT_Double:  return tc == 0 ? dt : ValidateDataType(dt - 2 * tc + 1);
     default:
       return dt;
   }


### PR DESCRIPTION
Raised in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19473

Fixes a non compliance w.r.t C++ standard:
https://wiki.sei.cmu.edu/confluence/display/cplusplus/INT50-CPP.+Do+not+cast+to+an+out-of-range+enumeration+value