### PR TITLE
Improve cmake based install to contain headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required (VERSION 3.11)
 project (Lerc)
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 17)
 
-file(GLOB SOURCES 
+file(GLOB SOURCES
     "src/LercLib/*"
     "src/LercLib/Lerc1Decode/*"
     "include"
@@ -12,5 +14,17 @@ message(${SOURCES})
 
 add_library(LercLib SHARED ${SOURCES})
 
-
 target_link_libraries (LercLib)
+
+install(
+    TARGETS LercLib
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_BINDIR}
+    PUBLIC_HEADER DESTINATION  ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    FILES "include/Lerc_types.h" "include/Lerc_c_api.h"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)


### PR DESCRIPTION
Do you really want this to be called `LercLib`. It creates so files

```
libLercLib.so
```
which would mean that you have to link with `-lLercLib`

Would you rather create `so` files that look like

```
libLerc.so
```
or without the capital (which I prefer)
```
liblerc.so
```