### PR TITLE
ARM portability: replace uses of char by explicit signed char

### DIFF
--- a/src/LercLib/Lerc.cpp
+++ b/src/LercLib/Lerc.cpp
@@ -41,7 +41,7 @@ ErrCode Lerc::ComputeCompressedSize(const void* pData, int version, DataType dt,
 {
   switch (dt)
   {
-  case DT_Char:    return ComputeCompressedSizeTempl((const char*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, numBytesNeeded);
+  case DT_Char:    return ComputeCompressedSizeTempl((const signed char*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, numBytesNeeded);
   case DT_Byte:    return ComputeCompressedSizeTempl((const Byte*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, numBytesNeeded);
   case DT_Short:   return ComputeCompressedSizeTempl((const short*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, numBytesNeeded);
   case DT_UShort:  return ComputeCompressedSizeTempl((const unsigned short*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, numBytesNeeded);
@@ -62,7 +62,7 @@ ErrCode Lerc::Encode(const void* pData, int version, DataType dt, int nDim, int 
 {
   switch (dt)
   {
-  case DT_Char:    return EncodeTempl((const char*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
+  case DT_Char:    return EncodeTempl((const signed char*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
   case DT_Byte:    return EncodeTempl((const Byte*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
   case DT_Short:   return EncodeTempl((const short*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
   case DT_UShort:  return EncodeTempl((const unsigned short*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
@@ -217,7 +217,7 @@ ErrCode Lerc::Decode(const Byte* pLercBlob, unsigned int numBytesBlob, BitMask* 
 {
   switch (dt)
   {
-  case DT_Char:    return DecodeTempl((char*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, pBitMask);
+  case DT_Char:    return DecodeTempl((signed char*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, pBitMask);
   case DT_Byte:    return DecodeTempl((Byte*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, pBitMask);
   case DT_Short:   return DecodeTempl((short*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, pBitMask);
   case DT_UShort:  return DecodeTempl((unsigned short*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, pBitMask);
@@ -237,7 +237,7 @@ ErrCode Lerc::ConvertToDouble(const void* pDataIn, DataType dt, size_t nDataValu
 {
   switch (dt)
   {
-  case DT_Char:    return ConvertToDoubleTempl((const char*)pDataIn, nDataValues, pDataOut);
+  case DT_Char:    return ConvertToDoubleTempl((const signed char*)pDataIn, nDataValues, pDataOut);
   case DT_Byte:    return ConvertToDoubleTempl((const Byte*)pDataIn, nDataValues, pDataOut);
   case DT_Short:   return ConvertToDoubleTempl((const short*)pDataIn, nDataValues, pDataOut);
   case DT_UShort:  return ConvertToDoubleTempl((const unsigned short*)pDataIn, nDataValues, pDataOut);

--- a/src/LercLib/Lerc2.cpp
+++ b/src/LercLib/Lerc2.cpp
@@ -270,7 +270,7 @@ unsigned int Lerc2::ComputeNumBytesNeededToWrite(const T* arr, double maxZError,
 
 // -------------------------------------------------------------------------- ;
 
-template unsigned int Lerc2::ComputeNumBytesNeededToWrite<char>(const char* arr, double maxZError, bool encodeMask);
+template unsigned int Lerc2::ComputeNumBytesNeededToWrite<signed char>(const signed char* arr, double maxZError, bool encodeMask);
 template unsigned int Lerc2::ComputeNumBytesNeededToWrite<Byte>(const Byte* arr, double maxZError, bool encodeMask);
 template unsigned int Lerc2::ComputeNumBytesNeededToWrite<short>(const short* arr, double maxZError, bool encodeMask);
 template unsigned int Lerc2::ComputeNumBytesNeededToWrite<unsigned short>(const unsigned short* arr, double maxZError, bool encodeMask);
@@ -350,7 +350,7 @@ bool Lerc2::Encode(const T* arr, Byte** ppByte)
 
 // -------------------------------------------------------------------------- ;
 
-template bool Lerc2::Encode<char>(const char* arr, Byte** ppByte);
+template bool Lerc2::Encode<signed char>(const signed char* arr, Byte** ppByte);
 template bool Lerc2::Encode<Byte>(const Byte* arr, Byte** ppByte);
 template bool Lerc2::Encode<short>(const short* arr, Byte** ppByte);
 template bool Lerc2::Encode<unsigned short>(const unsigned short* arr, Byte** ppByte);
@@ -480,7 +480,7 @@ bool Lerc2::Decode(const Byte** ppByte, size_t& nBytesRemaining, T* arr, Byte* p
 
 // -------------------------------------------------------------------------- ;
 
-template bool Lerc2::Decode<char>(const Byte** ppByte, size_t& nBytesRemaining, char* arr, Byte* pMaskBits);
+template bool Lerc2::Decode<signed char>(const Byte** ppByte, size_t& nBytesRemaining, signed char* arr, Byte* pMaskBits);
 template bool Lerc2::Decode<Byte>(const Byte** ppByte, size_t& nBytesRemaining, Byte* arr, Byte* pMaskBits);
 template bool Lerc2::Decode<short>(const Byte** ppByte, size_t& nBytesRemaining, short* arr, Byte* pMaskBits);
 template bool Lerc2::Decode<unsigned short>(const Byte** ppByte, size_t& nBytesRemaining, unsigned short* arr, Byte* pMaskBits);
@@ -1962,7 +1962,7 @@ Lerc2::DataType Lerc2::GetDataType(T z)
 {
   const std::type_info& ti = typeid(z);
 
-  if (ti == typeid(char))            return DT_Char;
+  if (ti == typeid(signed char))          return DT_Char;
   else if (ti == typeid(Byte))            return DT_Byte;
   else if (ti == typeid(short))           return DT_Short;
   else if (ti == typeid(unsigned short))  return DT_UShort;

--- a/src/LercLib/Lerc2.h
+++ b/src/LercLib/Lerc2.h
@@ -440,7 +440,7 @@ inline int Lerc2::ReduceDataType(T z, DataType dt, DataType& dtReduced)
   {
     case DT_Short:
     {
-      char c = (char)z;
+      signed char c = (signed char)z;
       int tc = (T)c == z ? 2 : (T)b == z ? 1 : 0;
       dtReduced = (DataType)(dt - tc);
       return tc;
@@ -528,7 +528,7 @@ bool Lerc2::WriteVariableDataType(Byte** ppByte, double z, DataType dtUsed)
   {
     case DT_Char:
     {
-      *((char*)ptr) = (char)z;
+      *((signed char*)ptr) = (signed char)z;
       ptr++;
       break;
     }
@@ -599,7 +599,7 @@ double Lerc2::ReadVariableDataType(const Byte** ppByte, DataType dtUsed)
   {
     case DT_Char:
     {
-      char c = *((char*)ptr);
+      signed char c = *((signed char*)ptr);
       *ppByte = ptr + 1;
       return c;
     }


### PR DESCRIPTION
There is no guarantee in C/C++ on the signedness of the 'char' type.
On ARM Linux, it happens to be unsigned, contrary to x86 Linux. So
be explicit and use 'signed char'.

Was found with GDAL when testing it on ARM64-Graviton2 platform in
https://github.com/OSGeo/gdal/pull/3598