### PR TITLE
Fix constructConstantSurface when checkMinMaxRanges was not called

### DIFF
--- a/OtherLanguages/js/LercDecode.js
+++ b/OtherLanguages/js/LercDecode.js
@@ -1621,7 +1621,9 @@ Contributors:  Johannes Schmid, (LERC v1)
           if (numDims > 1) {
             for (i = 0; i < numDims; i++) {
               nStart = i * numPixels;
-              val = data.headerInfo.maxValues[i];
+              if (data.headerInfo.maxValues) {
+                val = data.headerInfo.maxValues[i];
+              }
               for (k = 0; k < numPixels; k++) {
                 if (mask[k]) {
                   resultPixels[nStart + k] = val;
@@ -1641,7 +1643,9 @@ Contributors:  Johannes Schmid, (LERC v1)
           if (numDims > 1) {
             for (i = 0; i < numDims; i++) {
               nStart = i * numPixels;
-              val = data.headerInfo.maxValues[i];
+              if (data.headerInfo.maxValues) {
+                val = data.headerInfo.maxValues[i];
+              }
               for (k = 0; k < numPixels; k++) {
                 resultPixels[nStart + k] = val;
               }


### PR DESCRIPTION
headerInfo.maxValues is undefined in constructConstantSurface at

https://github.com/Esri/lerc/blob/a79aba07cd7ef9b718e2f77d44bab3655d98ba74/OtherLanguages/js/LercDecode.js#L1624

when it is called without calling checkMinMaxRanges by: https://github.com/Esri/lerc/blob/a79aba07cd7ef9b718e2f77d44bab3655d98ba74/OtherLanguages/js/LercDecode.js#L1947-L1950