### PR TITLE
tmaurer3/support_mask_per_band_and_nan

### DIFF
--- a/OtherLanguages/CSharp/LercDecode.cs
+++ b/OtherLanguages/CSharp/LercDecode.cs
@@ -31,14 +31,14 @@ namespace Lerc2017
 {
     class LercDecode
     {
-        const string lercDll = "Lerc64.dll";
+        const string lercDll = "Lerc.dll";
 
         // from Lerc_c_api.h :
         // 
         // typedef unsigned int lerc_status;
         //
         // // Call this function to get info about the compressed Lerc blob. Optional. 
-        // // Info returned in infoArray is { version, dataType, nDim, nCols, nRows, nBands, nValidPixels, blobSize }, see Lerc_types.h .
+        // // Info returned in infoArray is { version, dataType, nDim, nCols, nRows, nBands, nValidPixels, blobSize, nMasks }, see Lerc_types.h .
         // // Info returned in dataRangeArray is { zMin, zMax, maxZErrorUsed }, see Lerc_types.h .
         // // If more than 1 band the data range [zMin, zMax] is over all bands. 
         //
@@ -56,55 +56,60 @@ namespace Lerc2017
         // 
         // // Decode the compressed Lerc blob into a raw data array.
         // // The data array must have been allocated to size (nDim * nCols * nRows * nBands * sizeof(dataType)).
-        // // The valid bytes array, if not 0, must have been allocated to size (nCols * nRows). 
+        // // The valid bytes array, if not 0, must have been allocated to size (nCols * nRows * nMasks). 
         //
         // lerc_status lerc_decode(
         //   const unsigned char* pLercBlob,      // Lerc blob to decode
         //   unsigned int blobSize,               // blob size in bytes
+        //   int nMasks,                          // 0, 1, or nBands; return as many masks in the next array
         //   unsigned char* pValidBytes,          // gets filled if not null ptr, even if all valid
-        //   int nDim,                            // number of values per pixel (new)
+        //   int nDim,                            // number of values per pixel
         //   int nCols, int nRows, int nBands,    // number of columns, rows, bands
         //   unsigned int dataType,               // data type of outgoing array
         //   void* pData);                        // outgoing data array
 
         [DllImport(lercDll)]
-        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, sbyte[] pData);
+        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, int nMasks, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, sbyte[] pData);
         [DllImport(lercDll)]
-        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, byte[] pData);
+        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, int nMasks, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, byte[] pData);
         [DllImport(lercDll)]
-        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, short[] pData);
+        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, int nMasks, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, short[] pData);
         [DllImport(lercDll)]
-        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, ushort[] pData);
+        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, int nMasks, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, ushort[] pData);
         [DllImport(lercDll)]
-        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, Int32[] pData);
+        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, int nMasks, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, Int32[] pData);
         [DllImport(lercDll)]
-        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, UInt32[] pData);
+        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, int nMasks, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, UInt32[] pData);
         [DllImport(lercDll)]
-        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, float[] pData);
+        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, int nMasks, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, float[] pData);
         [DllImport(lercDll)]
-        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, double[] pData);
+        public static extern UInt32 lerc_decode(byte[] pLercBlob, UInt32 blobSize, int nMasks, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, int dataType, double[] pData);
 
         // if you are lazy, don't want to deal with generic / templated code, and don't care about wasting memory: 
         // this function decodes the pixel values into a tile of data type double, independent of the compressed data type.
 
         [DllImport(lercDll)]
-        public static extern UInt32 lerc_decodeToDouble(byte[] pLercBlob, UInt32 blobSize, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, double[] pData);
+        public static extern UInt32 lerc_decodeToDouble(byte[] pLercBlob, UInt32 blobSize, int nMasks, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands, double[] pData);
     }
 
     class GenericPixelLoop<T>
     {
-        public static void GetMinMax(T[] pData, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands)
+        public static void GetMinMax(T[] pData, int nMasks, byte[] pValidBytes, int nDim, int nCols, int nRows, int nBands)
         {
-            double zMin = 1e30;
+            double zMin = 1e40;
             double zMax = -zMin;
 
             // access the pixels; here, get the data range over all bands
             for (int iBand = 0; iBand < nBands; iBand++)
             {
+                int p0 = 0;
+                if (nMasks > 1)
+                    p0 = nCols * nRows * iBand;
+
                 int k0 = nCols * nRows * iBand;
                 for (int k = 0, i = 0; i < nRows; i++)
                     for (int j = 0; j < nCols; j++, k++)
-                        if (1 == pValidBytes[k])    // pixel is valid
+                        if (0 == nMasks || 1 == pValidBytes[p0 + k])    // pixel is valid
                         {
                             for (int m = 0; m < nDim; m++)
                             {
@@ -123,11 +128,11 @@ namespace Lerc2017
     {
         static void Main(string[] args)
         {
-            //byte[] pLercBlob = File.ReadAllBytes(@"../../../../testData/california_400_400_1_float.lerc2");
-            byte[] pLercBlob = File.ReadAllBytes(@"california_400_400_1_float.lerc2");
-            //byte[] pLercBlob = File.ReadAllBytes(@"../../../../testData/bluemarble_256_256_3_byte.lerc2");
+            //byte[] pLercBlob = File.ReadAllBytes(@"california_400_400_1_float.lerc2");
+            //byte[] pLercBlob = File.ReadAllBytes(@"bluemarble_256_256_3_byte.lerc2");
+            byte[] pLercBlob = File.ReadAllBytes(@"lerc_level_0.lerc2");
 
-            String[] infoLabels = { "version", "data type", "nDim", "nCols", "nRows", "nBands", "num valid pixels", "blob size" };
+            String[] infoLabels = { "version", "data type", "nDim", "nCols", "nRows", "nBands", "num valid pixels", "blob size", "nMasks" };
             String[] dataRangeLabels = { "zMin", "zMax", "maxZErrorUsed" };
 
             int infoArrSize = infoLabels.Count();
@@ -155,10 +160,11 @@ namespace Lerc2017
             int nCols = (int)infoArr[3];
             int nRows = (int)infoArr[4];
             int nBands = (int)infoArr[5];
+            int nMasks = (int)infoArr[8];
 
             Console.WriteLine("[zMin, zMax] = [{0}, {1}]", dataRangeArr[0], dataRangeArr[1]);
 
-            byte[] pValidBytes = new byte[nCols * nRows];
+            byte[] pValidBytes = new byte[nCols * nRows * nMasks];
             uint nValues = (uint)(nDim * nCols * nRows * nBands);
 
             Stopwatch sw = new Stopwatch();
@@ -169,65 +175,65 @@ namespace Lerc2017
                 case LercDecode.DataType.dt_char:
                     {
                         sbyte[] pData = new sbyte[nValues];
-                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
+                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, nMasks, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
                         if (hr == 0)
-                            GenericPixelLoop<sbyte>.GetMinMax(pData, pValidBytes, nDim, nCols, nRows, nBands);
+                            GenericPixelLoop<sbyte>.GetMinMax(pData, nMasks, pValidBytes, nDim, nCols, nRows, nBands);
                         break;
                     }
                 case LercDecode.DataType.dt_uchar:
                     {
                         byte[] pData = new byte[nValues];
-                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
+                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, nMasks, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
                         if (hr == 0)
-                            GenericPixelLoop<byte>.GetMinMax(pData, pValidBytes, nDim, nCols, nRows, nBands);
+                            GenericPixelLoop<byte>.GetMinMax(pData, nMasks, pValidBytes, nDim, nCols, nRows, nBands);
                         break;
                     }
                 case LercDecode.DataType.dt_short:
                     {
                         short[] pData = new short[nValues];
-                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
+                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, nMasks, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
                         if (hr == 0)
-                            GenericPixelLoop<short>.GetMinMax(pData, pValidBytes, nDim, nCols, nRows, nBands);
+                            GenericPixelLoop<short>.GetMinMax(pData, nMasks, pValidBytes, nDim, nCols, nRows, nBands);
                         break;
                     }
                 case LercDecode.DataType.dt_ushort:
                     {
                         ushort[] pData = new ushort[nValues];
-                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
+                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, nMasks, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
                         if (hr == 0)
-                            GenericPixelLoop<ushort>.GetMinMax(pData, pValidBytes, nDim, nCols, nRows, nBands);
+                            GenericPixelLoop<ushort>.GetMinMax(pData, nMasks, pValidBytes, nDim, nCols, nRows, nBands);
                         break;
                     }
                 case LercDecode.DataType.dt_int:
                     {
                         Int32[] pData = new Int32[nValues];
-                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
+                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, nMasks, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
                         if (hr == 0)
-                            GenericPixelLoop<Int32>.GetMinMax(pData, pValidBytes, nDim, nCols, nRows, nBands);
+                            GenericPixelLoop<Int32>.GetMinMax(pData, nMasks, pValidBytes, nDim, nCols, nRows, nBands);
                         break;
                     }
                 case LercDecode.DataType.dt_uint:
                     {
                         UInt32[] pData = new UInt32[nValues];
-                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
+                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, nMasks, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
                         if (hr == 0)
-                            GenericPixelLoop<UInt32>.GetMinMax(pData, pValidBytes, nDim, nCols, nRows, nBands);
+                            GenericPixelLoop<UInt32>.GetMinMax(pData, nMasks, pValidBytes, nDim, nCols, nRows, nBands);
                         break;
                     }
                 case LercDecode.DataType.dt_float:
                     {
                         float[] pData = new float[nValues];
-                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
+                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, nMasks, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
                         if (hr == 0)
-                            GenericPixelLoop<float>.GetMinMax(pData, pValidBytes, nDim, nCols, nRows, nBands);
+                            GenericPixelLoop<float>.GetMinMax(pData, nMasks, pValidBytes, nDim, nCols, nRows, nBands);
                         break;
                     }
                 case LercDecode.DataType.dt_double:
                     {
                         double[] pData = new double[nValues];
-                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
+                        hr = LercDecode.lerc_decode(pLercBlob, (UInt32)pLercBlob.Length, nMasks, pValidBytes, nDim, nCols, nRows, nBands, dataType, pData);
                         if (hr == 0)
-                            GenericPixelLoop<double>.GetMinMax(pData, pValidBytes, nDim, nCols, nRows, nBands);
+                            GenericPixelLoop<double>.GetMinMax(pData, nMasks, pValidBytes, nDim, nCols, nRows, nBands);
                         break;
                     }
             }

--- a/OtherLanguages/Python/lerc/_lerc.py
+++ b/OtherLanguages/Python/lerc/_lerc.py
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-#   Copyright 2016 - 2020 Esri
+#   Copyright 2016 - 2021 Esri
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -26,12 +26,12 @@
 #
 #   How to use:
 #
-#   You need 2 files, this file "Lerc.py" and the Lerc dll (for Windows) or the
+#   You need 2 files, this file "_lerc.py" and the Lerc dll (for Windows) or the
 #   Lerc .so file (for Linux). Set the path below so the Lerc dll or .so file
 #   can be read from here. You don't need a pip install or any installer. Then
 #
-#   >>> import Lerc
-#   >>> Lerc.test()
+#   >>> import _lerc
+#   >>> _lerc.test()
 #
 #-------------------------------------------------------------------------------
 
@@ -48,6 +48,7 @@ if platform.system() == "Linux":
     lercDll = ct.CDLL (os.path.join(dir_path, 'Lerc.so'))
 if platform.system() == "Darwin":
     lercDll = ct.CDLL (os.path.join(dir_path, 'Lerc.dylib'))
+
 #-------------------------------------------------------------------------------
 
 # helper functions:
@@ -82,12 +83,12 @@ def getLercShape(npArr, nValuesPerPixel):
         if dim == 2:
             (nRows, nCols) = npShape
         elif dim == 3:
-            (nBands, nRows, nCols) = npShape
+            (nBands, nRows, nCols) = npShape  # or band interleaved
     elif nValuesPerPixel > 1:
         if dim == 3:
-            (nRows, nCols, nValpp) = npShape
+            (nRows, nCols, nValpp) = npShape  # or pixel interleaved
         elif dim == 4:
-            (nBands, nRows, nCols, nValpp) = npShape
+            (nBands, nRows, nCols, nValpp) = npShape  # 4D array
         if nValpp != nValuesPerPixel:
             return (0, 0, 0)
 
@@ -103,21 +104,23 @@ def findMaxZError(npArr1, npArr2):
 
 #-------------------------------------------------------------------------------
 
-def findDataRange(npArr, npValidMask, nCols, nRows, nBands, nValidPixels, printInfo = False):
+def findDataRange(npArr, bHasMask, npValidMask, nBands, printInfo = False):
     start = timer()
-    if (nValidPixels == nRows * nCols):
+
+    if not bHasMask:
         zMin = np.amin(npArr)
         zMax = np.amax(npArr)
     else:
-        if nBands == 1:
+        if nBands == 1 or npValidMask.ndim == 3:  # one mask per band
             zMin = np.amin(npArr[npValidMask])
             zMax = np.amax(npArr[npValidMask])
-        elif nBands > 1:
+        elif nBands > 1:  # same mask for all bands
             zMin = float("inf")
             zMax = -zMin
             for m in range(nBands):
                 zMin = min(np.amin(npArr[m][npValidMask]), zMin)
                 zMax = max(np.amax(npArr[m][npValidMask]), zMax)
+
     end = timer()
     if printInfo:
         print('time findDataRange() = ', (end - start))
@@ -128,20 +131,34 @@ def findDataRange(npArr, npValidMask, nCols, nRows, nBands, nValidPixels, printI
 # see include/Lerc_c_api.h
 
 lercDll.lerc_computeCompressedSize.restype = ct.c_uint
-lercDll.lerc_computeCompressedSize.argtypes = (ct.c_void_p, ct.c_uint, ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.c_char_p, ct.c_double, ct.POINTER(ct.c_uint))
+lercDll.lerc_computeCompressedSize.argtypes = (ct.c_void_p, ct.c_uint, ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.c_char_p, ct.c_double, ct.POINTER(ct.c_uint))
 
 lercDll.lerc_encode.restype = ct.c_uint
-lercDll.lerc_encode.argtypes = (ct.c_void_p, ct.c_uint, ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.c_char_p, ct.c_double, ct.c_char_p, ct.c_uint, ct.POINTER(ct.c_uint))
+lercDll.lerc_encode.argtypes = (ct.c_void_p, ct.c_uint, ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.c_char_p, ct.c_double, ct.c_char_p, ct.c_uint, ct.POINTER(ct.c_uint))
 
 lercDll.lerc_getBlobInfo.restype = ct.c_uint
 lercDll.lerc_getBlobInfo.argtypes = (ct.c_char_p, ct.c_uint, ct.POINTER(ct.c_uint), ct.POINTER(ct.c_double), ct.c_int, ct.c_int)
 
 lercDll.lerc_decode.restype = ct.c_uint
-lercDll.lerc_decode.argtypes = (ct.c_char_p, ct.c_uint, ct.c_char_p, ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.c_uint, ct.c_void_p)
+lercDll.lerc_decode.argtypes = (ct.c_char_p, ct.c_uint, ct.c_int, ct.c_char_p, ct.c_int, ct.c_int, ct.c_int, ct.c_int, ct.c_uint, ct.c_void_p)
 
 #-------------------------------------------------------------------------------
 
-def encode(npArr, nValuesPerPixel, npValidMask, maxZErr, outBuffer, printInfo = False):
+# npArr can be 2D, 3D, or 4D array. See also getLercShape() above.
+#
+# npValidMask can be None (bHasMask == False), 2D byte array, or 3D byte array (bHasMask == True).
+# if 2D or [nRows, nCols], it is one mask for all bands. 1 means pixel is valid, 0 means invalid.
+# if 3D or [nBands, nRows, nCols], it is one mask PER band.
+# note that an array of values per pixel is either all valid or all invalid.
+# the case that such inner array values are partially valid or invalid is not represented by a mask
+# yet but a noData value would have to be used.
+#
+# nBytesHint can be
+#  0 - compute num bytes needed for output buffer, but do not encode it (faster than encode)
+#  1 - do both, compute exact buffer size needed and encode (slower than encode alone)
+#  > 1 - create buffer of that given size and encode, if buffer too small encode will fail. 
+
+def encode(npArr, nValuesPerPixel, bHasMask, npValidMask, maxZErr, nBytesHint, printInfo = False):
     global lercDll
     
     dataType = getLercDatatype(npArr.dtype)
@@ -154,59 +171,87 @@ def encode(npArr, nValuesPerPixel, npValidMask, maxZErr, outBuffer, printInfo = 
         print('Error in encode(): unsupported numpy array shape.')
         return (-1, 0)
 
+    nMasks = 0
+    if bHasMask:
+        (nMasks, nRows2, nCols2) = getLercShape(npValidMask, 1)
+        if not(nMasks == 0 or nMasks == 1 or nMasks == nBands) or not(nRows2 == nRows and nCols2 == nCols):
+            print('Error in encode(): unsupported mask array shape.')
+            return (-1, 0)
+
     if printInfo:
         print('dataType = ', dataType)
         print('nBands = ', nBands)
         print('nRows = ', nRows)
         print('nCols = ', nCols)
         print('nValuesPerPixel = ', nValuesPerPixel)
+        print('nMasks = ', nMasks)
     
     byteArr = npArr.tobytes('C')  # C order
     cpData = ct.cast(byteArr, ct.c_void_p)
-    npValidBytes = npValidMask.astype('B')
-    validArr = npValidBytes.tobytes('C')
-    cpValidArr = ct.cast(validArr, ct.c_char_p)
-    ptr = ct.cast((ct.c_uint * 1)(), ct.POINTER(ct.c_uint))
 
-    start = timer()
-    
-    if outBuffer == None:
-        result = lercDll.lerc_computeCompressedSize(cpData, dataType, nValuesPerPixel, nCols, nRows, nBands, cpValidArr, maxZErr, ptr)
+    if bHasMask:
+        npValidBytes = npValidMask.astype('B')
+        validArr = npValidBytes.tobytes('C')
+        cpValidArr = ct.cast(validArr, ct.c_char_p)
     else:
-        result = lercDll.lerc_encode(cpData, dataType, nValuesPerPixel, nCols, nRows, nBands, cpValidArr, maxZErr, outBuffer, len(outBuffer), ptr)
+        cpValidArr = None
 
-    end = timer()
+    ptr = ct.cast((ct.c_uint * 1)(), ct.POINTER(ct.c_uint))
     
-    if result > 0:
-        print('Error in encode(): lercDll function failed with error code = ', result)
-        return (result, 0)
+    if nBytesHint == 0 or nBytesHint == 1:
+        start = timer()
+        result = lercDll.lerc_computeCompressedSize(cpData, dataType, nValuesPerPixel, nCols, nRows, nBands, nMasks, cpValidArr, maxZErr, ptr)
+        nBytesNeeded = ptr[0]
+        end = timer()
 
-    if printInfo:
-        if outBuffer == None:
+        if result > 0:
+            print('Error in encode(): lercDll.lerc_computeCompressedSize() failed with error code = ', result)
+            return (result, 0)
+
+        if printInfo:
             print('time lerc_computeCompressedSize() = ', (end - start))
-        else:
+    else:
+        nBytesNeeded = nBytesHint
+
+    if nBytesHint > 0:
+        outBytes = ct.create_string_buffer(nBytesNeeded)
+        cpOutBuffer = ct.cast(outBytes, ct.c_char_p)
+        start = timer()
+        result = lercDll.lerc_encode(cpData, dataType, nValuesPerPixel, nCols, nRows, nBands, nMasks, cpValidArr, maxZErr, cpOutBuffer, nBytesNeeded, ptr)
+        nBytesWritten = ptr[0]
+        end = timer()
+
+        if result > 0:
+            print('Error in encode(): lercDll.lerc_encode() failed with error code = ', result)
+            return (result, 0)
+
+        if printInfo:
             print('time lerc_encode() = ', (end - start))
-        
-    return (result, ptr[0])
+
+    if nBytesHint == 0:
+        return (result, nBytesNeeded)
+    else:
+        return (result, nBytesWritten, outBytes)
 
 #-------------------------------------------------------------------------------
 
-def getLercBlobInfo(compressedBytes, printInfo = False):
+def getLercBlobInfo(lercBlob, printInfo = False):
     global lercDll
     
-    info = ['version', 'data type', 'nValuesPerPixel', 'nCols', 'nRows', 'nBands', 'nValidPixels', 'blob size']
+    info = ['version', 'data type', 'nValuesPerPixel', 'nCols', 'nRows', 'nBands', 'nValidPixels', 'blob size', 'nMasks']
     dataRange = ['zMin', 'zMax', 'maxZErrorUsed']
-    nBytes = len(compressedBytes)
+
+    nBytes = len(lercBlob)
     len0 = len(info)
     len1 = len(dataRange)
     p0 = ct.cast((ct.c_uint * len0)(), ct.POINTER(ct.c_uint))
     p1 = ct.cast((ct.c_double * len1)(), ct.POINTER(ct.c_double))
-    cpBytes = ct.cast(compressedBytes, ct.c_char_p)
+    cpBytes = ct.cast(lercBlob, ct.c_char_p)
     
     result = lercDll.lerc_getBlobInfo(cpBytes, nBytes, p0, p1, len0, len1)
     if result > 0:
         print('Error in getLercBlobInfo(): lercDLL.lerc_getBlobInfo() failed with error code = ', result)
-        return (result, 0,0,0,0,0,0,0,0,0,0,0)
+        return (result, 0,0,0,0,0,0,0,0,0,0,0,0)
 
     if printInfo:
         for i in range(len0):
@@ -214,14 +259,14 @@ def getLercBlobInfo(compressedBytes, printInfo = False):
         for i in range(len1):
             print(dataRange[i], p1[i])
     
-    return (result, p0[0], p0[1], p0[2], p0[3], p0[4], p0[5], p0[6], p0[7], p1[0], p1[1], p1[2])
+    return (result, p0[0], p0[1], p0[2], p0[3], p0[4], p0[5], p0[6], p0[7], p0[8], p1[0], p1[1], p1[2])
 
 #-------------------------------------------------------------------------------
 
 def decode(lercBlob, printInfo = False):
     global lercDll
 
-    (result, version, dataType, nValuesPerPixel, nCols, nRows, nBands, nValidPixels, blobSize, zMin, zMax, maxZErrUsed) = getLercBlobInfo(lercBlob)
+    (result, version, dataType, nValuesPerPixel, nCols, nRows, nBands, nValidPixels, blobSize, nMasks, zMin, zMax, maxZErrUsed) = getLercBlobInfo(lercBlob, printInfo)
     if result > 0:
         print('Error in decode(): getLercBlobInfo() failed with error code = ', result)
         return result
@@ -249,16 +294,17 @@ def decode(lercBlob, printInfo = False):
     cpData = ct.cast(dataBuf, ct.c_void_p)
     cpBytes = ct.cast(lercBlob, ct.c_char_p)
 
-    # create empty buffer for valid pixels mask, if needed
+    # create empty buffer for valid pixels masks, if needed
     cpValidArr = None
-    if nValidPixels != nRows * nCols:    # not all pixels are valid, need mask
-        validBuf = ct.create_string_buffer(nRows * nCols)
+    if nMasks > 0:
+        validBuf = ct.create_string_buffer(nMasks * nRows * nCols)
         cpValidArr = ct.cast(validBuf, ct.c_char_p)
 
     # call decode
     start = timer()
-    result = lercDll.lerc_decode(cpBytes, len(lercBlob), cpValidArr, nValuesPerPixel, nCols, nRows, nBands, dataType, cpData)
+    result = lercDll.lerc_decode(cpBytes, len(lercBlob), nMasks, cpValidArr, nValuesPerPixel, nCols, nRows, nBands, dataType, cpData)
     end = timer()
+
     if result > 0:
         print('Error in decode(): lercDll.lerc_decode() failed with error code = ', result)
         return result
@@ -270,9 +316,13 @@ def decode(lercBlob, printInfo = False):
     npArr = np.frombuffer(dataBuf, npDtype)
     npArr.shape = shape
 
-    if nValidPixels != nRows * nCols:
+    if nMasks > 0:
         npValidBytes = np.frombuffer(validBuf, dtype='B')
-        npValidBytes.shape = (nRows, nCols)
+        if nMasks == 1:
+            npValidBytes.shape = (nRows, nCols)
+        else:
+            npValidBytes.shape = (nMasks, nRows, nCols)
+
         npValidMask = (npValidBytes != 0)
         return (result, npArr, npValidMask)
     else:
@@ -294,7 +344,8 @@ def test():
     nValuesPerPixel = 3  # values or array per pixel, could be RGB values or hyper spectral image
     
     npArr = np.zeros((nRows, nCols, nValuesPerPixel), 'f', 'C')  # data type float, C order
-    npValidMask = np.full((nRows, nCols), True)  # set all pixels valid
+    #npValidMask = np.full((nRows, nCols), True)  # set all pixels valid
+    npValidMask = None  # same as all pixels valid
     maxZErr = 0.001
 
     # fill it with something
@@ -303,16 +354,16 @@ def test():
             for k in range(nValuesPerPixel):
                 npArr[i][j][k] = 0.001 * i * j + k
 
-    # call w/o outBuffer to only compute compressed size, optional
-    (result, numBytes) = encode(npArr, nValuesPerPixel, npValidMask, maxZErr, None, True)
+    # call with buffer size 0 to only compute compressed size, optional
+    numBytesNeeded = 0
+    (result, numBytesNeeded) = encode(npArr, nValuesPerPixel, False, npValidMask, maxZErr, numBytesNeeded, True)
     if result > 0:
         print('Error in test(): error code = ', result)
         return result
-    print('computed compressed size = ', numBytes)
+    print('computed compressed size = ', numBytesNeeded)
 
-    # encode
-    outBuffer = '0' * numBytes    # or use buffer bigger than needed
-    (result, numBytesWritten) = encode(npArr, nValuesPerPixel, npValidMask, maxZErr, outBuffer, True)
+    # encode with numBytesNeeded from above or big enough estimate
+    (result, numBytesWritten, outBuffer) = encode(npArr, nValuesPerPixel, False, npValidMask, maxZErr, numBytesNeeded, True)
     if result > 0:
         print('Error in test(): error code = ', result)
         return result
@@ -324,9 +375,13 @@ def test():
         print('Error in test(): decode() failed with error code = ', result)
         return result
 
-    # evaluate the difference to orig
+    # evaluate the difference to orig (assuming no mask all valid)
     maxZErrFound = findMaxZError(npArr, npArrDec)
     print('maxZErr found = ', maxZErrFound)
+
+    # find the range [zMin, zMax] in the numpy array
+    (zMin, zMax) = findDataRange(npArrDec, False, None, nBands, True)
+    print('data range found = ', zMin, zMax)
 
     print(' -------- encode test 2 -------- ')
 
@@ -345,16 +400,9 @@ def test():
             for j in range(nCols):
                 npArr[m][i][j] = 0.001 * i * j + m
 
-    # call w/o outBuffer to only compute compressed size, optional
-    (result, numBytes) = encode(npArr, nValuesPerPixel, npValidMask, maxZErr, None, True)
-    if result > 0:
-        print('Error in encode(): error code = ', result)
-        return result
-    print('computed compressed size = ', numBytes)
-
     # encode
-    outBuffer = '0' * numBytes
-    (result, numBytesWritten) = encode(npArr, nValuesPerPixel, npValidMask, maxZErr, outBuffer, True)
+    nBytesBigEnough = npArr.nbytes * 2
+    (result, numBytesWritten, outBuffer) = encode(npArr, nValuesPerPixel, True, npValidMask, maxZErr, nBytesBigEnough, True)
     if result > 0:
         print('Error in encode(): error code = ', result)
         return result
@@ -366,38 +414,42 @@ def test():
         print('Error in test(): decode() failed with error code = ', result)
         return result
 
-    # evaluate the difference to orig
+    # evaluate the difference to orig (assuming no mask all valid)
     maxZErrFound = findMaxZError(npArr, npArrDec)
     print('maxZErr found = ', maxZErrFound)
     
     # save compressed Lerc blob to disk
     #open('C:/temp/test_1_256_256_3_double.lrc', 'wb').write(outBuffer)
 
-    print(' -------- decode tests -------- ')
+    if False:
+        print(' -------- decode tests -------- ')
 
-    folder = 'D:/GitHub/LercOpenSource/testData/'
-    files = ['california_400_400_1_float.lerc2',
-             'bluemarble_256_256_3_byte.lerc2',
-             #'landsat_512_512_6_byte.lerc2',
-             'world.lerc1']
+        folder = 'D:/GitHub/LercOpenSource_v2.5/testData/'
+        files = ['california_400_400_1_float.lerc2',
+                 'bluemarble_256_256_3_byte.lerc2',
+                 'landsat_512_512_6_byte.lerc2',
+                 'world.lerc1',
+                 'Different_Masks/lerc_level_0.lerc2']
 
-    for n in range(len(files)):
-        fn = folder + files[n]
-        bytesRead = open(fn, 'rb').read()
-        
-        (result, version, dataType, nValuesPerPixel, nCols, nRows, nBands, nValidPixels, blobSize, zMin, zMax, maxZErrUsed) = getLercBlobInfo(bytesRead, True)
-        if result > 0:
-            print('Error in test(): getLercBlobInfo() failed with error code = ', result)
-            return result
+        for n in range(len(files)):
+            fn = folder + files[n]
+            bytesRead = open(fn, 'rb').read()
 
-        (result, npArr, npValidMask) = decode(bytesRead, True)
-        if result > 0:
-            print('Error in test(): decode() failed with error code = ', result)
-            return result
+            # read the blob header, optional
+            (result, version, dataType, nValuesPerPixel, nCols, nRows, nBands, nValidPixels, blobSize, nMasks, zMin, zMax, maxZErrUsed) = getLercBlobInfo(bytesRead, False)
+            if result > 0:
+                print('Error in test(): getLercBlobInfo() failed with error code = ', result)
+                return result
 
-        # find the range [zMin, zMax] in the numpy array and compare to the above
-        (zMin, zMax) = findDataRange(npArr, npValidMask, nCols, nRows, nBands, nValidPixels, True)
-        print('data range found = ', zMin, zMax)
-        print('------')
+            # decode
+            (result, npArr, npValidMask) = decode(bytesRead, True)
+            if result > 0:
+                print('Error in test(): decode() failed with error code = ', result)
+                return result
+
+            # find the range [zMin, zMax] in the numpy array and compare to the above
+            (zMin, zMax) = findDataRange(npArr, nMasks > 0, npValidMask, nBands, True)
+            print('data range found = ', zMin, zMax)
+            print('------')
     
     return result

--- a/include/Lerc_c_api.h
+++ b/include/Lerc_c_api.h
@@ -52,7 +52,7 @@ extern "C" {
 
   //! The image or mask of valid pixels is optional. Null pointer means all pixels are valid. 
   //! If not all pixels are valid, set invalid pixel bytes to 0, valid pixel bytes to 1. 
-  //! Size of the valid / invalid pixel image is nCols x nRows. 
+  //! Size of the valid / invalid pixel image is (nCols * nRows * nMasks). 
 
   LERCDLL_API
   lerc_status lerc_computeCompressedSize(
@@ -62,6 +62,7 @@ extern "C" {
     int nCols,                         // number of columns
     int nRows,                         // number of rows
     int nBands,                        // number of bands (e.g., 3 for [RRRR ..., GGGG ..., BBBB ...])
+    int nMasks,                        // 0 - all valid, 1 - same mask for all bands, nBands - masks can differ between bands
     const unsigned char* pValidBytes,  // null ptr if all pixels are valid; otherwise 1 byte per pixel (1 = valid, 0 = invalid)
     double maxZErr,                    // max coding error per pixel, defines the precision
     unsigned int* numBytes);           // size of outgoing Lerc blob
@@ -77,6 +78,7 @@ extern "C" {
     int nCols,                         // number of columns
     int nRows,                         // number of rows
     int nBands,                        // number of bands (e.g., 3 for [RRRR ..., GGGG ..., BBBB ...])
+    int nMasks,                        // 0 - all valid, 1 - same mask for all bands, nBands - masks can differ between bands
     const unsigned char* pValidBytes,  // null ptr if all pixels are valid; otherwise 1 byte per pixel (1 = valid, 0 = invalid)
     double maxZErr,                    // max coding error per pixel, defines the precision
     unsigned char* pOutBuffer,         // buffer to write to, function fails if buffer too small
@@ -95,6 +97,7 @@ extern "C" {
     int nCols,                         // number of columns
     int nRows,                         // number of rows
     int nBands,                        // number of bands (e.g., 3 for [RRRR ..., GGGG ..., BBBB ...])
+    int nMasks,                        // 0 - all valid, 1 - same mask for all bands, nBands - masks can differ between bands
     const unsigned char* pValidBytes,  // null ptr if all pixels are valid; otherwise 1 byte per pixel (1 = valid, 0 = invalid)
     double maxZErr,                    // max coding error per pixel, defines the precision
     unsigned int* numBytes);           // size of outgoing Lerc blob
@@ -108,6 +111,7 @@ extern "C" {
     int nCols,                         // number of columns
     int nRows,                         // number of rows
     int nBands,                        // number of bands (e.g., 3 for [RRRR ..., GGGG ..., BBBB ...])
+    int nMasks,                        // 0 - all valid, 1 - same mask for all bands, nBands - masks can differ between bands
     const unsigned char* pValidBytes,  // null ptr if all pixels are valid; otherwise 1 byte per pixel (1 = valid, 0 = invalid)
     double maxZErr,                    // max coding error per pixel, defines the precision
     unsigned char* pOutBuffer,         // buffer to write to, function fails if buffer too small
@@ -116,7 +120,7 @@ extern "C" {
 
 
   //! Call this to get info about the compressed Lerc blob. Optional. 
-  //! Info returned in infoArray is { version, dataType, nDim, nCols, nRows, nBands, nValidPixels, blobSize }, see Lerc_types.h .
+  //! Info returned in infoArray is { version, dataType, nDim, nCols, nRows, nBands, nValidPixels, blobSize, nMasks }, see Lerc_types.h .
   //! Info returned in dataRangeArray is { zMin, zMax, maxZErrorUsed }, see Lerc_types.h .
   //! If nDim > 1 or nBands > 1 the data range [zMin, zMax] is over all values. 
 
@@ -134,7 +138,7 @@ extern "C" {
   lerc_status lerc_getBlobInfo(
     const unsigned char* pLercBlob,    // Lerc blob to decode
     unsigned int blobSize,             // blob size in bytes
-    unsigned int* infoArray,           // info array with all info needed to allocate the outgoing array for calling decode
+    unsigned int* infoArray,           // info array with all info needed to allocate the outgoing arrays for calling decode
     double* dataRangeArray,            // quick access to overall data range [zMin, zMax] without having to decode the data
     int infoArraySize,                 // number of elements of infoArray
     int dataRangeArraySize);           // number of elements of dataRangeArray
@@ -142,12 +146,13 @@ extern "C" {
 
   //! Decode the compressed Lerc blob into a raw data array.
   //! The data array must have been allocated to size (nDim * nCols * nRows * nBands * sizeof(dataType)).
-  //! The valid pixels array, if not 0, must have been allocated to size (nCols * nRows). 
+  //! The valid pixels array, if not all pixels valid, must have been allocated to size (nCols * nRows * nMasks). 
 
   LERCDLL_API
   lerc_status lerc_decode(
     const unsigned char* pLercBlob,    // Lerc blob to decode
     unsigned int blobSize,             // blob size in bytes
+    int nMasks,                        // 0, 1, or nBands; return as many masks in the next array
     unsigned char* pValidBytes,        // gets filled if not null ptr, even if all valid
     int nDim,                          // number of values per pixel (e.g., 3 for RGB, data is stored as [RGB, RGB, ...])
     int nCols,                         // number of columns
@@ -167,6 +172,7 @@ extern "C" {
   lerc_status lerc_decodeToDouble(
     const unsigned char* pLercBlob,    // Lerc blob to decode
     unsigned int blobSize,             // blob size in bytes
+    int nMasks,                        // 0, 1, or nBands; return as many masks in the next array
     unsigned char* pValidBytes,        // gets filled if not null ptr, even if all valid
     int nDim,                          // number of values per pixel (e.g., 3 for RGB, data is stored as [RGB, RGB, ...])
     int nCols,                         // number of columns

--- a/include/Lerc_types.h
+++ b/include/Lerc_types.h
@@ -37,8 +37,9 @@ namespace LercNS
     nCols,
     nRows,
     nBands,
-    nValidPixels,
-    blobSize
+    nValidPixels,  // for 1st band
+    blobSize,
+    nMasks  // 0 - all valid, 1 - same mask for all bands, nBands - masks can differ between bands
   };
 
   enum class DataRangeArrOrder : int

--- a/src/LercLib/Defines.h
+++ b/src/LercLib/Defines.h
@@ -37,7 +37,6 @@ Contributors:  Thomas Maurer, Lucian Plesea
 #define USING_NAMESPACE_LERC using namespace LercNS;
 
 #define HAVE_LERC1_DECODE
-//#define CHECK_FOR_NAN
 
 NAMESPACE_LERC_START
 

--- a/src/LercLib/Lerc.cpp
+++ b/src/LercLib/Lerc.cpp
@@ -37,18 +37,18 @@ USING_NAMESPACE_LERC
 // -------------------------------------------------------------------------- ;
 
 ErrCode Lerc::ComputeCompressedSize(const void* pData, int version, DataType dt, int nDim, int nCols, int nRows, int nBands,
-  const BitMask* pBitMask, double maxZErr, unsigned int& numBytesNeeded)
+  int nMasks, const Byte* pValidBytes, double maxZErr, unsigned int& numBytesNeeded)
 {
   switch (dt)
   {
-  case DT_Char:    return ComputeCompressedSizeTempl((const signed char*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, numBytesNeeded);
-  case DT_Byte:    return ComputeCompressedSizeTempl((const Byte*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, numBytesNeeded);
-  case DT_Short:   return ComputeCompressedSizeTempl((const short*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, numBytesNeeded);
-  case DT_UShort:  return ComputeCompressedSizeTempl((const unsigned short*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, numBytesNeeded);
-  case DT_Int:     return ComputeCompressedSizeTempl((const int*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, numBytesNeeded);
-  case DT_UInt:    return ComputeCompressedSizeTempl((const unsigned int*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, numBytesNeeded);
-  case DT_Float:   return ComputeCompressedSizeTempl((const float*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, numBytesNeeded);
-  case DT_Double:  return ComputeCompressedSizeTempl((const double*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, numBytesNeeded);
+  case DT_Char:    return ComputeCompressedSizeTempl((const signed char*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, numBytesNeeded);
+  case DT_Byte:    return ComputeCompressedSizeTempl((const Byte*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, numBytesNeeded);
+  case DT_Short:   return ComputeCompressedSizeTempl((const short*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, numBytesNeeded);
+  case DT_UShort:  return ComputeCompressedSizeTempl((const unsigned short*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, numBytesNeeded);
+  case DT_Int:     return ComputeCompressedSizeTempl((const int*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, numBytesNeeded);
+  case DT_UInt:    return ComputeCompressedSizeTempl((const unsigned int*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, numBytesNeeded);
+  case DT_Float:   return ComputeCompressedSizeTempl((const float*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, numBytesNeeded);
+  case DT_Double:  return ComputeCompressedSizeTempl((const double*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, numBytesNeeded);
 
   default:
     return ErrCode::WrongParam;
@@ -58,18 +58,18 @@ ErrCode Lerc::ComputeCompressedSize(const void* pData, int version, DataType dt,
 // -------------------------------------------------------------------------- ;
 
 ErrCode Lerc::Encode(const void* pData, int version, DataType dt, int nDim, int nCols, int nRows, int nBands,
-  const BitMask* pBitMask, double maxZErr, Byte* pBuffer, unsigned int numBytesBuffer, unsigned int& numBytesWritten)
+  int nMasks, const Byte* pValidBytes, double maxZErr, Byte* pBuffer, unsigned int numBytesBuffer, unsigned int& numBytesWritten)
 {
   switch (dt)
   {
-  case DT_Char:    return EncodeTempl((const signed char*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
-  case DT_Byte:    return EncodeTempl((const Byte*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
-  case DT_Short:   return EncodeTempl((const short*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
-  case DT_UShort:  return EncodeTempl((const unsigned short*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
-  case DT_Int:     return EncodeTempl((const int*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
-  case DT_UInt:    return EncodeTempl((const unsigned int*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
-  case DT_Float:   return EncodeTempl((const float*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
-  case DT_Double:  return EncodeTempl((const double*)pData, version, nDim, nCols, nRows, nBands, pBitMask, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
+  case DT_Char:    return EncodeTempl((const signed char*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
+  case DT_Byte:    return EncodeTempl((const Byte*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
+  case DT_Short:   return EncodeTempl((const short*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
+  case DT_UShort:  return EncodeTempl((const unsigned short*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
+  case DT_Int:     return EncodeTempl((const int*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
+  case DT_UInt:    return EncodeTempl((const unsigned int*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
+  case DT_Float:   return EncodeTempl((const float*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
+  case DT_Double:  return EncodeTempl((const double*)pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr, pBuffer, numBytesBuffer, numBytesWritten);
 
   default:
     return ErrCode::WrongParam;
@@ -84,13 +84,16 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
 
   // first try Lerc2
   struct Lerc2::HeaderInfo lerc2Info;
-  if (Lerc2::GetHeaderInfo(pLercBlob, numBytesBlob, lerc2Info))
+  bool bHasMask = false;
+  int nMasks = 0;
+
+  if (Lerc2::GetHeaderInfo(pLercBlob, numBytesBlob, lerc2Info, bHasMask))
   {
     lercInfo.version = lerc2Info.version;
     lercInfo.nDim = lerc2Info.nDim;
     lercInfo.nCols = lerc2Info.nCols;
     lercInfo.nRows = lerc2Info.nRows;
-    lercInfo.numValidPixel = lerc2Info.numValidPixel;
+    lercInfo.numValidPixel = lerc2Info.numValidPixel;    // for 1st band
     lercInfo.nBands = 1;
     lercInfo.blobSize = lerc2Info.blobSize;
     lercInfo.dt = (DataType)lerc2Info.dt;
@@ -98,21 +101,26 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
     lercInfo.zMax = lerc2Info.zMax;
     lercInfo.maxZError = lerc2Info.maxZError;
 
+    if (bHasMask || lercInfo.numValidPixel == 0)
+      nMasks = 1;
+
     if (lercInfo.blobSize > (int)numBytesBlob)    // truncated blob, we won't be able to read this band
       return ErrCode::BufferTooSmall;
 
     struct Lerc2::HeaderInfo hdInfo;
-    while (Lerc2::GetHeaderInfo(pLercBlob + lercInfo.blobSize, numBytesBlob - lercInfo.blobSize, hdInfo))
+    while (Lerc2::GetHeaderInfo(pLercBlob + lercInfo.blobSize, numBytesBlob - lercInfo.blobSize, hdInfo, bHasMask))
     {
       if (hdInfo.nDim != lercInfo.nDim
        || hdInfo.nCols != lercInfo.nCols
        || hdInfo.nRows != lercInfo.nRows
-       || hdInfo.numValidPixel != lercInfo.numValidPixel
        || (int)hdInfo.dt != (int)lercInfo.dt)
-       //|| hdInfo.maxZError != lercInfo.maxZError)  // with the new bitplane compression, maxZError can vary between bands
+       //|| hdInfo.maxZError != lercInfo.maxZError)    // with the new bitplane compression, maxZError can vary between bands
       {
         return ErrCode::Failed;
       }
+
+      if (bHasMask || hdInfo.numValidPixel != lercInfo.numValidPixel)    // support mask per band
+        nMasks = 2;
 
       if (lercInfo.blobSize > std::numeric_limits<int>::max() - hdInfo.blobSize)
         return ErrCode::Failed;
@@ -127,6 +135,8 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
       lercInfo.zMax = max(lercInfo.zMax, hdInfo.zMax);
       lercInfo.maxZError = max(lercInfo.maxZError, hdInfo.maxZError);  // with the new bitplane compression, maxZError can vary between bands
     }
+
+    lercInfo.nMasks = nMasks > 1 ? lercInfo.nBands : nMasks;
 
     return ErrCode::Ok;
   }
@@ -201,6 +211,7 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
       lercInfo.numValidPixel = numValidPixels;
       lercInfo.zMin = std::min(lercInfo.zMin, (double)zMin);
       lercInfo.zMax = std::max(lercInfo.zMax, (double)zMax);
+      lercInfo.nMasks = numValidPixels < width * height ? 1 : 0;
     }
 
     return ErrCode::Ok;
@@ -212,19 +223,19 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
 
 // -------------------------------------------------------------------------- ;
 
-ErrCode Lerc::Decode(const Byte* pLercBlob, unsigned int numBytesBlob, BitMask* pBitMask,
+ErrCode Lerc::Decode(const Byte* pLercBlob, unsigned int numBytesBlob, int nMasks, Byte* pValidBytes,
   int nDim, int nCols, int nRows, int nBands, DataType dt, void* pData)
 {
   switch (dt)
   {
-  case DT_Char:    return DecodeTempl((signed char*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, pBitMask);
-  case DT_Byte:    return DecodeTempl((Byte*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, pBitMask);
-  case DT_Short:   return DecodeTempl((short*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, pBitMask);
-  case DT_UShort:  return DecodeTempl((unsigned short*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, pBitMask);
-  case DT_Int:     return DecodeTempl((int*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, pBitMask);
-  case DT_UInt:    return DecodeTempl((unsigned int*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, pBitMask);
-  case DT_Float:   return DecodeTempl((float*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, pBitMask);
-  case DT_Double:  return DecodeTempl((double*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, pBitMask);
+  case DT_Char:    return DecodeTempl((signed char*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, nMasks, pValidBytes);
+  case DT_Byte:    return DecodeTempl((Byte*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, nMasks, pValidBytes);
+  case DT_Short:   return DecodeTempl((short*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, nMasks, pValidBytes);
+  case DT_UShort:  return DecodeTempl((unsigned short*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, nMasks, pValidBytes);
+  case DT_Int:     return DecodeTempl((int*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, nMasks, pValidBytes);
+  case DT_UInt:    return DecodeTempl((unsigned int*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, nMasks, pValidBytes);
+  case DT_Float:   return DecodeTempl((float*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, nMasks, pValidBytes);
+  case DT_Double:  return DecodeTempl((double*)pData, pLercBlob, numBytesBlob, nDim, nCols, nRows, nBands, nMasks, pValidBytes);
 
   default:
     return ErrCode::WrongParam;
@@ -256,105 +267,52 @@ ErrCode Lerc::ConvertToDouble(const void* pDataIn, DataType dt, size_t nDataValu
 
 template<class T>
 ErrCode Lerc::ComputeCompressedSizeTempl(const T* pData, int version, int nDim, int nCols, int nRows, int nBands,
-  const BitMask* pBitMask, double maxZErr, unsigned int& numBytesNeeded)
+  int nMasks, const Byte* pValidBytes, double maxZErr, unsigned int& numBytesNeeded)
 {
   numBytesNeeded = 0;
 
   if (!pData || nDim <= 0 || nCols <= 0 || nRows <= 0 || nBands <= 0 || maxZErr < 0)
     return ErrCode::WrongParam;
 
-  if (pBitMask && (pBitMask->GetHeight() != nRows || pBitMask->GetWidth() != nCols))
+  if (!(nMasks == 0 || nMasks == 1 || nMasks == nBands) || (nMasks > 0 && !pValidBytes))
     return ErrCode::WrongParam;
 
-  Lerc2 lerc2;
-  if (version >= 0 && !lerc2.SetEncoderToOldVersion(version))
-    return ErrCode::WrongParam;
+  unsigned int numBytesWritten = 0;
 
-  bool rv = pBitMask ? lerc2.Set(nDim, nCols, nRows, pBitMask->Bits()) : lerc2.Set(nDim, nCols, nRows);
-  if (!rv)
-    return ErrCode::Failed;
-
-  // loop over the bands
-  for (int iBand = 0; iBand < nBands; iBand++)
-  {
-    bool encMsk = (iBand == 0);    // store bit mask with first band only
-    const T* arr = pData + nDim * nCols * nRows * iBand;
-
-    ErrCode errCode = CheckForNaN(arr, nDim, nCols, nRows, pBitMask);
-    if (errCode != ErrCode::Ok)
-      return errCode;
-
-    unsigned int nBytes = lerc2.ComputeNumBytesNeededToWrite(arr, maxZErr, encMsk);
-    if (nBytes <= 0)
-      return ErrCode::Failed;
-
-    numBytesNeeded += nBytes;
-  }
-
-  return ErrCode::Ok;
+  return EncodeInternal(pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr,
+    numBytesNeeded, nullptr, 0, numBytesWritten);
 }
 
 // -------------------------------------------------------------------------- ;
 
 template<class T>
 ErrCode Lerc::EncodeTempl(const T* pData, int version, int nDim, int nCols, int nRows, int nBands,
-  const BitMask* pBitMask, double maxZErr, Byte* pBuffer, unsigned int numBytesBuffer, unsigned int& numBytesWritten)
+  int nMasks, const Byte* pValidBytes, double maxZErr, Byte* pBuffer, unsigned int numBytesBuffer, unsigned int& numBytesWritten)
 {
   numBytesWritten = 0;
 
   if (!pData || nDim <= 0 || nCols <= 0 || nRows <= 0 || nBands <= 0 || maxZErr < 0 || !pBuffer || !numBytesBuffer)
     return ErrCode::WrongParam;
 
-  if (pBitMask && (pBitMask->GetHeight() != nRows || pBitMask->GetWidth() != nCols))
+  if (!(nMasks == 0 || nMasks == 1 || nMasks == nBands) || (nMasks > 0 && !pValidBytes))
     return ErrCode::WrongParam;
 
-  Lerc2 lerc2;
-  if (version >= 0 && !lerc2.SetEncoderToOldVersion(version))
-    return ErrCode::WrongParam;
+  unsigned int numBytesNeeded = 0;
 
-  bool rv = pBitMask ? lerc2.Set(nDim, nCols, nRows, pBitMask->Bits()) : lerc2.Set(nDim, nCols, nRows);
-  if (!rv)
-    return ErrCode::Failed;
-
-  Byte* pByte = pBuffer;
-
-  // loop over the bands, encode into array of single band Lerc blobs
-  for (int iBand = 0; iBand < nBands; iBand++)
-  {
-    bool encMsk = (iBand == 0);    // store bit mask with first band only
-    const T* arr = pData + nDim * nCols * nRows * iBand;
-
-    ErrCode errCode = CheckForNaN(arr, nDim, nCols, nRows, pBitMask);
-    if (errCode != ErrCode::Ok)
-      return errCode;
-
-    unsigned int nBytes = lerc2.ComputeNumBytesNeededToWrite(arr, maxZErr, encMsk);
-    if (nBytes == 0)
-      return ErrCode::Failed;
-
-    unsigned int nBytesAlloc = nBytes;
-
-    if ((size_t)(pByte - pBuffer) + nBytesAlloc > numBytesBuffer)    // check we have enough space left
-      return ErrCode::BufferTooSmall;
-
-    if (!lerc2.Encode(arr, &pByte))
-      return ErrCode::Failed;
-  }
-
-  numBytesWritten = (unsigned int)(pByte - pBuffer);
-  return ErrCode::Ok;
+  return EncodeInternal(pData, version, nDim, nCols, nRows, nBands, nMasks, pValidBytes, maxZErr,
+    numBytesNeeded, pBuffer, numBytesBuffer, numBytesWritten);
 }
 
 // -------------------------------------------------------------------------- ;
 
 template<class T>
 ErrCode Lerc::DecodeTempl(T* pData, const Byte* pLercBlob, unsigned int numBytesBlob,
-  int nDim, int nCols, int nRows, int nBands, BitMask* pBitMask)
+  int nDim, int nCols, int nRows, int nBands, int nMasks, Byte* pValidBytes)
 {
   if (!pData || nDim <= 0 || nCols <= 0 || nRows <= 0 || nBands <= 0 || !pLercBlob || !numBytesBlob)
     return ErrCode::WrongParam;
 
-  if (pBitMask && (pBitMask->GetHeight() != nRows || pBitMask->GetWidth() != nCols))
+  if (!(nMasks == 0 || nMasks == 1 || nMasks == nBands) || (nMasks > 0 && !pValidBytes))
     return ErrCode::WrongParam;
 
   const Byte* pByte = pLercBlob;
@@ -362,15 +320,27 @@ ErrCode Lerc::DecodeTempl(T* pData, const Byte* pLercBlob, unsigned int numBytes
   Byte* pByte1 = const_cast<Byte*>(pLercBlob);
 #endif
   Lerc2::HeaderInfo hdInfo;
+  bool bHasMask = false;
 
-  if (Lerc2::GetHeaderInfo(pByte, numBytesBlob, hdInfo) && hdInfo.version >= 1)    // is Lerc2
+  if (Lerc2::GetHeaderInfo(pByte, numBytesBlob, hdInfo, bHasMask) && hdInfo.version >= 1)    // if Lerc2
   {
+    LercInfo lercInfo;
+    ErrCode errCode = GetLercInfo(pLercBlob, numBytesBlob, lercInfo);    // fast for Lerc2
+    if (errCode != ErrCode::Ok)
+      return errCode;
+
+    const int nMasksEncoded = lercInfo.nMasks;    // 0, 1, or nBands
+
+    if (nMasks < nMasksEncoded)
+      return ErrCode::WrongParam;
+
     size_t nBytesRemaining = numBytesBlob;
     Lerc2 lerc2;
+    BitMask bitMask;
 
     for (int iBand = 0; iBand < nBands; iBand++)
     {
-      if (((size_t)(pByte - pLercBlob) < numBytesBlob) && Lerc2::GetHeaderInfo(pByte, nBytesRemaining, hdInfo))
+      if (((size_t)(pByte - pLercBlob) < numBytesBlob) && Lerc2::GetHeaderInfo(pByte, nBytesRemaining, hdInfo, bHasMask))
       {
         if (hdInfo.nDim != nDim || hdInfo.nCols != nCols || hdInfo.nRows != nRows)
           return ErrCode::Failed;
@@ -380,11 +350,19 @@ ErrCode Lerc::DecodeTempl(T* pData, const Byte* pLercBlob, unsigned int numBytes
 
         T* arr = pData + nDim * nCols * nRows * iBand;
 
-        if (!lerc2.Decode(&pByte, nBytesRemaining, arr, (pBitMask && iBand == 0) ? pBitMask->Bits() : nullptr))
+        bool bGetMask = iBand < nMasks;
+
+        if (bGetMask && !bitMask.SetSize(nCols, nRows))
+          return ErrCode::Failed;
+
+        if (!lerc2.Decode(&pByte, nBytesRemaining, arr, bGetMask ? bitMask.Bits() : nullptr))
+          return ErrCode::Failed;
+
+        if (bGetMask && !Convert(bitMask, pValidBytes + iBand * nCols * nRows))
           return ErrCode::Failed;
       }
-    }
-  }
+    }  // iBand
+  }  // Lerc2
 
   else    // might be old Lerc1
   {
@@ -407,8 +385,9 @@ ErrCode Lerc::DecodeTempl(T* pData, const Byte* pLercBlob, unsigned int numBytes
         return ErrCode::Failed;
 
       T* arr = pData + nCols * nRows * iBand;
+      Byte* pDst = iBand < nMasks ? pValidBytes + nCols * nRows * iBand : nullptr;
 
-      if (!Convert(zImg, arr, pBitMask))
+      if (!Convert(zImg, arr, pDst, iBand == 0))
         return ErrCode::Failed;
     }
 #else
@@ -422,9 +401,108 @@ ErrCode Lerc::DecodeTempl(T* pData, const Byte* pLercBlob, unsigned int numBytes
 // -------------------------------------------------------------------------- ;
 // -------------------------------------------------------------------------- ;
 
+template<class T>
+ErrCode Lerc::EncodeInternal(const T* pData, int version, int nDim, int nCols, int nRows, int nBands,
+  int nMasks, const Byte* pValidBytes, double maxZErr, unsigned int& numBytesNeeded,
+  Byte* pBuffer, unsigned int numBytesBuffer, unsigned int& numBytesWritten)
+{
+  numBytesNeeded = 0;
+  numBytesWritten = 0;
+
+  Lerc2 lerc2;
+  if (version >= 0 && !lerc2.SetEncoderToOldVersion(version))
+    return ErrCode::WrongParam;
+
+  Byte* pDst = pBuffer;
+
+  const int nPixels = nCols * nRows;
+  const int nElem = nDim * nPixels;
+
+  const Byte* pPrevByteMask = nullptr;
+  vector<T> dataBuffer;
+  vector<Byte> maskBuffer, prevMaskBuffer;
+  BitMask bitMask;
+
+  // loop over the bands
+  for (int iBand = 0; iBand < nBands; iBand++)
+  {
+    bool bEncMsk = (iBand == 0);
+
+    // using the proper section of valid bytes, check this band for NaN
+    const T* arr = pData + nElem * iBand;
+    const Byte* pByteMask = (nMasks > 0) ? (pValidBytes + ((nMasks > 1) ? nPixels * iBand : 0)) : nullptr;
+
+    ErrCode errCode = CheckForNaN(arr, nDim, nCols, nRows, pByteMask);
+    if (errCode != ErrCode::Ok && errCode != ErrCode::NaN)
+      return errCode;
+
+    if (errCode == ErrCode::NaN)    // found NaN values
+    {
+      if (!Resize(dataBuffer, nElem) || !Resize(maskBuffer, nPixels))
+        return ErrCode::Failed;
+
+      memcpy(&dataBuffer[0], arr, nElem * sizeof(T));
+      pByteMask ? memcpy(&maskBuffer[0], pByteMask, nPixels) : memset(&maskBuffer[0], 1, nPixels);
+
+      if (!ReplaceNaNValues(dataBuffer, maskBuffer, nDim, nCols, nRows))
+        return ErrCode::Failed;
+
+      if (iBand > 0 && MasksDiffer(&maskBuffer[0], pPrevByteMask, nPixels))
+        bEncMsk = true;
+
+      if (iBand < nBands - 1)
+      {
+        // keep current mask as new previous band mask
+        prevMaskBuffer = maskBuffer;
+        pPrevByteMask = &prevMaskBuffer[0];
+      }
+
+      arr = &dataBuffer[0];
+      pByteMask = &maskBuffer[0];
+    }
+
+    else    // no NaN in this band, the common case
+    {
+      if (iBand > 0 && MasksDiffer(pByteMask, pPrevByteMask, nPixels))
+        bEncMsk = true;
+
+      pPrevByteMask = pByteMask;
+    }
+
+    if (bEncMsk)
+    {
+      if (pByteMask && !Convert(pByteMask, nCols, nRows, bitMask))
+        return ErrCode::Failed;
+
+      if (!lerc2.Set(nDim, nCols, nRows, pByteMask ? bitMask.Bits() : nullptr))
+        return ErrCode::Failed;
+    }
+
+    unsigned int nBytes = lerc2.ComputeNumBytesNeededToWrite(arr, maxZErr, bEncMsk);
+    if (nBytes <= 0)
+      return ErrCode::Failed;
+
+    numBytesNeeded += nBytes;
+
+    if (pBuffer)
+    {
+      if ((size_t)(pDst - pBuffer) + nBytes > numBytesBuffer)    // check we have enough space left
+        return ErrCode::BufferTooSmall;
+
+      if (!lerc2.Encode(arr, &pDst))
+        return ErrCode::Failed;
+    }
+  }
+
+  numBytesWritten = (unsigned int)(pDst - pBuffer);
+  return ErrCode::Ok;
+}
+
+// -------------------------------------------------------------------------- ;
+
 #ifdef HAVE_LERC1_DECODE
 template<class T>
-bool Lerc::Convert(const CntZImage& zImg, T* arr, BitMask* pBitMask)
+bool Lerc::Convert(const CntZImage& zImg, T* arr, Byte* pByteMask, bool bMustFillMask)
 {
   if (!arr || !zImg.getSize())
     return false;
@@ -434,24 +512,40 @@ bool Lerc::Convert(const CntZImage& zImg, T* arr, BitMask* pBitMask)
   int h = zImg.getHeight();
   int w = zImg.getWidth();
 
-  if (pBitMask && (pBitMask->GetHeight() != h || pBitMask->GetWidth() != w))
-    return false;
-
-  if (pBitMask)
-    pBitMask->SetAllValid();
-
   const CntZ* srcPtr = zImg.getData();
   T* dstPtr = arr;
   int num = w * h;
-  for (int k = 0; k < num; k++)
-  {
-    if (srcPtr->cnt > 0)
-      *dstPtr = fltPnt ? (T)srcPtr->z : (T)floor(srcPtr->z + 0.5);
-    else if (pBitMask)
-      pBitMask->SetInvalid(k);
 
-    srcPtr++;
-    dstPtr++;
+  if (pByteMask)
+  {
+    memset(pByteMask, 0, num);
+
+    for (int k = 0; k < num; k++)
+    {
+      if (srcPtr->cnt > 0)
+      {
+        *dstPtr = fltPnt ? (T)srcPtr->z : (T)floor(srcPtr->z + 0.5);
+        pByteMask[k] = 1;
+      }
+
+      srcPtr++;
+      dstPtr++;
+    }
+  }
+  else
+  {
+    for (int k = 0; k < num; k++)
+    {
+      if (srcPtr->cnt > 0)
+      {
+        *dstPtr = fltPnt ? (T)srcPtr->z : (T)floor(srcPtr->z + 0.5);
+      }
+      else if (bMustFillMask)
+        return false;
+
+      srcPtr++;
+      dstPtr++;
+    }
   }
 
   return true;
@@ -474,47 +568,152 @@ ErrCode Lerc::ConvertToDoubleTempl(const T* pDataIn, size_t nDataValues, double*
 
 // -------------------------------------------------------------------------- ;
 
-template<class T> ErrCode Lerc::CheckForNaN(const T* arr, int nDim, int nCols, int nRows, const BitMask* pBitMask)
+template<class T> ErrCode Lerc::CheckForNaN(const T* arr, int nDim, int nCols, int nRows, const Byte* pByteMask)
 {
   if (!arr || nDim <= 0 || nCols <= 0 || nRows <= 0)
     return ErrCode::WrongParam;
- 
-#ifdef CHECK_FOR_NAN
 
-  if (typeid(T) == typeid(double) || typeid(T) == typeid(float))
+  if (typeid(T) != typeid(double) && typeid(T) != typeid(float))
+    return ErrCode::Ok;
+
+  for (int k = 0, i = 0; i < nRows; i++)
   {
-    bool foundNaN = false;
+    bool bFoundNaN = false;
+    const T* rowArr = &(arr[i * nCols * nDim]);
 
-    for (int k = 0, i = 0; i < nRows; i++)
+    if (!pByteMask)    // all valid
     {
-      const T* rowArr = &(arr[i * nCols * nDim]);
-
-      if (!pBitMask)    // all valid
-      {
-        for (int n = 0, j = 0; j < nCols; j++, n += nDim)
+      int num = nCols * nDim;
+      for (int m = 0; m < num; m++)
+        if (std::isnan((double)rowArr[m]))
+          bFoundNaN = true;
+    }
+    else    // not all valid
+    {
+      for (int n = 0, j = 0; j < nCols; j++, k++, n += nDim)
+        if (pByteMask[k])
+        {
           for (int m = 0; m < nDim; m++)
             if (std::isnan((double)rowArr[n + m]))
-              foundNaN = true;
-      }
-      else    // not all valid
-      {
-        for (int n = 0, j = 0; j < nCols; j++, k++, n += nDim)
-          if (pBitMask->IsValid(k))
-          {
-            for (int m = 0; m < nDim; m++)
-              if (std::isnan((double)rowArr[n + m]))
-                foundNaN = true;
-          }
-      }
+              bFoundNaN = true;
+        }
+    }
 
-      if (foundNaN)
-        return ErrCode::NaN;
+    if (bFoundNaN)
+      return ErrCode::NaN;
+  }
+
+  return ErrCode::Ok;
+}
+
+// -------------------------------------------------------------------------- ;
+
+template<class T> bool Lerc::ReplaceNaNValues(std::vector<T>& dataBuffer, std::vector<Byte>& maskBuffer, int nDim, int nCols, int nRows)
+{
+  if (nDim <= 0 || nCols <= 0 || nRows <= 0 || dataBuffer.size() != nDim * nCols * nRows || maskBuffer.size() != nCols * nRows)
+    return false;
+
+  bool bIsFloat = (typeid(T) == typeid(float));
+  const T noDataValue = (T)(bIsFloat ? -FLT_MAX : -DBL_MAX);
+
+  for (int k = 0, i = 0; i < nRows; i++)
+  {
+    T* rowArr = &(dataBuffer[i * nCols * nDim]);
+
+    for (int n = 0, j = 0; j < nCols; j++, k++, n += nDim)
+    {
+      if (maskBuffer[k])
+      {
+        int cntNaN = 0;
+
+        for (int m = 0; m < nDim; m++)
+          if (std::isnan((double)rowArr[n + m]))
+          {
+            cntNaN++;
+            rowArr[n + m] = noDataValue;
+          }
+
+        if (cntNaN == nDim)
+          maskBuffer[k] = 0;
+      }
     }
   }
 
-#endif
+  return true;
+}
 
-  return ErrCode::Ok;
+// -------------------------------------------------------------------------- ;
+
+template<class T> bool Lerc::Resize(std::vector<T>& buffer, int nElem)
+{
+  if (nElem < 0)
+    return false;
+
+  try
+  {
+    buffer.resize(nElem);
+  }
+  catch (...)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+// -------------------------------------------------------------------------- ;
+
+bool Lerc::Convert(const Byte* pByteMask, int nCols, int nRows, BitMask& bitMask)
+{
+  if (!pByteMask || nCols <= 0 || nRows <= 0)
+    return false;
+
+  if (!bitMask.SetSize(nCols, nRows))
+    return false;
+
+  bitMask.SetAllValid();
+
+  for (int k = 0, i = 0; i < nRows; i++)
+    for (int j = 0; j < nCols; j++, k++)
+      if (!pByteMask[k])
+        bitMask.SetInvalid(k);
+
+  return true;
+}
+
+// -------------------------------------------------------------------------- ;
+
+bool Lerc::Convert(const BitMask& bitMask, Byte* pByteMask)
+{
+  int nCols = bitMask.GetWidth();
+  int nRows = bitMask.GetHeight();
+
+  if (nCols <= 0 || nRows <= 0 || !pByteMask)
+    return false;
+
+  memset(pByteMask, 0, nCols * nRows);
+
+  for (int k = 0, i = 0; i < nRows; i++)
+    for (int j = 0; j < nCols; j++, k++)
+      if (bitMask.IsValid(k))
+        pByteMask[k] = 1;
+
+  return true;
+}
+
+// -------------------------------------------------------------------------- ;
+
+bool Lerc::MasksDiffer(const Byte* p0, const Byte* p1, size_t n)
+{
+  if (p0 == p1)
+    return false;
+
+  if (!p0)    // means all valid
+    return memchr(p1, 0, n);    // any invalid?
+  else if (!p1)
+    return memchr(p0, 0, n);
+  else
+    return memcmp(p0, p1, n);
 }
 
 // -------------------------------------------------------------------------- ;

--- a/src/LercLib/Lerc2.cpp
+++ b/src/LercLib/Lerc2.cpp
@@ -361,12 +361,21 @@ template bool Lerc2::Encode<double>(const double* arr, Byte** ppByte);
 
 // -------------------------------------------------------------------------- ;
 
-bool Lerc2::GetHeaderInfo(const Byte* pByte, size_t nBytesRemaining, struct HeaderInfo& hd)
+bool Lerc2::GetHeaderInfo(const Byte* pByte, size_t nBytesRemaining, struct HeaderInfo& hd, bool& bHasMask)
 {
   if (!pByte || !IsLittleEndianSystem())
     return false;
 
-  return ReadHeader(&pByte, nBytesRemaining, hd);
+  if (!ReadHeader(&pByte, nBytesRemaining, hd))
+    return false;
+
+  int numBytesMask(0);
+  if (nBytesRemaining < sizeof(int) || !memcpy(&numBytesMask, pByte, sizeof(int)))
+    return false;
+
+  bHasMask = numBytesMask > 0;
+
+  return true;
 }
 
 // -------------------------------------------------------------------------- ;

--- a/src/LercLib/Lerc2.h
+++ b/src/LercLib/Lerc2.h
@@ -111,7 +111,7 @@ public:
     bool TryHuffman() const  { return version > 1 && (dt == DT_Byte || dt == DT_Char) && maxZError == 0.5; }
   };
 
-  static bool GetHeaderInfo(const Byte* pByte, size_t nBytesRemaining, struct HeaderInfo& headerInfo);
+  static bool GetHeaderInfo(const Byte* pByte, size_t nBytesRemaining, struct HeaderInfo& headerInfo, bool& bHasMask);
 
   /// dst buffer already allocated;  byte ptr is moved like a file pointer
   template<class T>

--- a/src/LercLib/Lerc_c_api.h
+++ b/src/LercLib/Lerc_c_api.h
@@ -52,7 +52,7 @@ extern "C" {
 
   //! The image or mask of valid pixels is optional. Null pointer means all pixels are valid. 
   //! If not all pixels are valid, set invalid pixel bytes to 0, valid pixel bytes to 1. 
-  //! Size of the valid / invalid pixel image is nCols x nRows. 
+  //! Size of the valid / invalid pixel image is (nCols * nRows * nMasks). 
 
   LERCDLL_API
   lerc_status lerc_computeCompressedSize(
@@ -62,6 +62,7 @@ extern "C" {
     int nCols,                         // number of columns
     int nRows,                         // number of rows
     int nBands,                        // number of bands (e.g., 3 for [RRRR ..., GGGG ..., BBBB ...])
+    int nMasks,                        // 0 - all valid, 1 - same mask for all bands, nBands - masks can differ between bands
     const unsigned char* pValidBytes,  // null ptr if all pixels are valid; otherwise 1 byte per pixel (1 = valid, 0 = invalid)
     double maxZErr,                    // max coding error per pixel, defines the precision
     unsigned int* numBytes);           // size of outgoing Lerc blob
@@ -77,6 +78,7 @@ extern "C" {
     int nCols,                         // number of columns
     int nRows,                         // number of rows
     int nBands,                        // number of bands (e.g., 3 for [RRRR ..., GGGG ..., BBBB ...])
+    int nMasks,                        // 0 - all valid, 1 - same mask for all bands, nBands - masks can differ between bands
     const unsigned char* pValidBytes,  // null ptr if all pixels are valid; otherwise 1 byte per pixel (1 = valid, 0 = invalid)
     double maxZErr,                    // max coding error per pixel, defines the precision
     unsigned char* pOutBuffer,         // buffer to write to, function fails if buffer too small
@@ -95,6 +97,7 @@ extern "C" {
     int nCols,                         // number of columns
     int nRows,                         // number of rows
     int nBands,                        // number of bands (e.g., 3 for [RRRR ..., GGGG ..., BBBB ...])
+    int nMasks,                        // 0 - all valid, 1 - same mask for all bands, nBands - masks can differ between bands
     const unsigned char* pValidBytes,  // null ptr if all pixels are valid; otherwise 1 byte per pixel (1 = valid, 0 = invalid)
     double maxZErr,                    // max coding error per pixel, defines the precision
     unsigned int* numBytes);           // size of outgoing Lerc blob
@@ -108,6 +111,7 @@ extern "C" {
     int nCols,                         // number of columns
     int nRows,                         // number of rows
     int nBands,                        // number of bands (e.g., 3 for [RRRR ..., GGGG ..., BBBB ...])
+    int nMasks,                        // 0 - all valid, 1 - same mask for all bands, nBands - masks can differ between bands
     const unsigned char* pValidBytes,  // null ptr if all pixels are valid; otherwise 1 byte per pixel (1 = valid, 0 = invalid)
     double maxZErr,                    // max coding error per pixel, defines the precision
     unsigned char* pOutBuffer,         // buffer to write to, function fails if buffer too small
@@ -116,7 +120,7 @@ extern "C" {
 
 
   //! Call this to get info about the compressed Lerc blob. Optional. 
-  //! Info returned in infoArray is { version, dataType, nDim, nCols, nRows, nBands, nValidPixels, blobSize }, see Lerc_types.h .
+  //! Info returned in infoArray is { version, dataType, nDim, nCols, nRows, nBands, nValidPixels, blobSize, nMasks }, see Lerc_types.h .
   //! Info returned in dataRangeArray is { zMin, zMax, maxZErrorUsed }, see Lerc_types.h .
   //! If nDim > 1 or nBands > 1 the data range [zMin, zMax] is over all values. 
 
@@ -134,7 +138,7 @@ extern "C" {
   lerc_status lerc_getBlobInfo(
     const unsigned char* pLercBlob,    // Lerc blob to decode
     unsigned int blobSize,             // blob size in bytes
-    unsigned int* infoArray,           // info array with all info needed to allocate the outgoing array for calling decode
+    unsigned int* infoArray,           // info array with all info needed to allocate the outgoing arrays for calling decode
     double* dataRangeArray,            // quick access to overall data range [zMin, zMax] without having to decode the data
     int infoArraySize,                 // number of elements of infoArray
     int dataRangeArraySize);           // number of elements of dataRangeArray
@@ -142,12 +146,13 @@ extern "C" {
 
   //! Decode the compressed Lerc blob into a raw data array.
   //! The data array must have been allocated to size (nDim * nCols * nRows * nBands * sizeof(dataType)).
-  //! The valid pixels array, if not 0, must have been allocated to size (nCols * nRows). 
+  //! The valid pixels array, if not all pixels valid, must have been allocated to size (nCols * nRows * nMasks). 
 
   LERCDLL_API
   lerc_status lerc_decode(
     const unsigned char* pLercBlob,    // Lerc blob to decode
     unsigned int blobSize,             // blob size in bytes
+    int nMasks,                        // 0, 1, or nBands; return as many masks in the next array
     unsigned char* pValidBytes,        // gets filled if not null ptr, even if all valid
     int nDim,                          // number of values per pixel (e.g., 3 for RGB, data is stored as [RGB, RGB, ...])
     int nCols,                         // number of columns
@@ -167,6 +172,7 @@ extern "C" {
   lerc_status lerc_decodeToDouble(
     const unsigned char* pLercBlob,    // Lerc blob to decode
     unsigned int blobSize,             // blob size in bytes
+    int nMasks,                        // 0, 1, or nBands; return as many masks in the next array
     unsigned char* pValidBytes,        // gets filled if not null ptr, even if all valid
     int nDim,                          // number of values per pixel (e.g., 3 for RGB, data is stored as [RGB, RGB, ...])
     int nCols,                         // number of columns

--- a/src/LercLib/Lerc_types.h
+++ b/src/LercLib/Lerc_types.h
@@ -37,8 +37,9 @@ namespace LercNS
     nCols,
     nRows,
     nBands,
-    nValidPixels,
-    blobSize
+    nValidPixels,  // for 1st band
+    blobSize,
+    nMasks  // 0 - all valid, 1 - same mask for all bands, nBands - masks can differ between bands
   };
 
   enum class DataRangeArrOrder : int


### PR DESCRIPTION
_ 1) Support valid / invalid pixel byte masks that can differ between bands (main reason for this update). Esri's software can write such Lerc blobs. 

  _ API calls change from "..., unsigned char* pValidBytes, ..." to "..., int nMasks, unsigend char* pValidBytes, ...". 
  _ For Encode
    _ If all pixels are valid and no mask is needed, call it with "..., 0, nullptr, ...". 
    _ If not all pixels are valid and a mask is needed but same for all bands, call it with "..., 1, pValidBytes, ...". Same as before. 
    _ If masks vary between bands, call it with "..., nBands, pValidBytes, ...". And allocate pValidBytes to (nBands * nRows * nCols). 
  _ For Decode
    _ Via GetLercBlobInfo(), query how many masks are encoded in the Lerc blob. Valid numbers are 0, 1, or nBands. 
       Then call Decode same as Encode. You can ask for more masks than encoded, in that case they get duplicated. 

  _ Internal byte stream and Lerc encode version is not changed. Existing Lerc blobs can still be read. Lerc blobs written by the new API can still be read by the previous Lerc API as long as nMasks <= 1. 

_ 2) Support NaN pixels in float or double input data. 

  _ The new API checks valid pixels for NaN. If found, it converts NaN to invalid pixels encoded in the byte mask. With the above change, this is always possible unless nDim (or nDepth) > 1 and the array per pixel can have a mix of valid and invalid values. In that case NaN gets converted into -MAXFLT for float or -MAXDBL for double. 

