### PR TITLE
Lerc_c_api.h: add macros to identify the version

### DIFF
--- a/HOWTO-RELEASE.md
+++ b/HOWTO-RELEASE.md
@@ -1,0 +1,4 @@
+Release procedure
+-----------------
+
+Update version numbers in include/Lerc_c_api.h

--- a/include/Lerc_c_api.h
+++ b/include/Lerc_c_api.h
@@ -28,6 +28,23 @@ Contributors:  Thomas Maurer
 extern "C" {
 #endif
 
+/* LERC version numbers and related macros added in 3.0.0 */
+
+#define LERC_VERSION_MAJOR 3
+#define LERC_VERSION_MINOR 0
+#define LERC_VERSION_PATCH 0
+
+/* Macro to compute a LERC version number from its components */
+#define LERC_COMPUTE_VERSION(maj,min,patch) ((maj)*10000+(min)*100+(patch))
+
+/* Current LERC version from the above version numbers */
+#define LERC_VERSION_NUMBER                 \
+    LERC_COMPUTE_VERSION(LERC_VERSION_MAJOR, LERC_VERSION_MINOR, LERC_VERSION_PATCH)
+
+/* Macro that returns true if the current LERC version is at least the version specified by (maj,min,patch) */
+#define LERC_AT_LEAST_VERSION(maj,min,patch) \
+    (LERC_VERSION_NUMBER >= LERC_COMPUTE_VERSION(maj,min,patch))
+
 #if defined(_MSC_VER)
   #define LERCDLL_API __declspec(dllexport)
 #elif __GNUC__ >= 4


### PR DESCRIPTION
as liblerc is now used in external project, such as the
soon-to-be-released libtiff 4.3.0, it is important we can identify which
version we include to cope with API changes

It would also be good to avoid API breakages in the C API to make the
life of downstream consumers easier.