### PR TITLE
update python package version for v3.0 release

### DIFF
--- a/OtherLanguages/Python/setup.py
+++ b/OtherLanguages/Python/setup.py
@@ -29,7 +29,7 @@ for platform in PLATFORMS:
 
 setuptools.setup(
     name="lerc",
-    version="2.2",
+    version="3.0",
     author="esri",
     author_email="python@esri.com",
     description="Limited Error Raster Compression",

--- a/build/conda/lerc/meta.yaml
+++ b/build/conda/lerc/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: lerc
-  version: 2.2
+  version: 3.0
 
 build:
   noarch: python


### PR DESCRIPTION
Bumps up the lerc python (package) version to **3.0**.
 
cc @scw 