### PR TITLE
tmaurer3/new_fct_get_data_ranges

### DIFF
--- a/src/LercLib/Lerc.h
+++ b/src/LercLib/Lerc.h
@@ -126,8 +126,11 @@ NAMESPACE_LERC_START
     // If in doubt, check the code in Lerc::GetLercInfo(...) for the exact logic. 
 
     static ErrCode GetLercInfo(const Byte* pLercBlob,       // Lerc blob to decode
-                               unsigned int numBytesBlob,   // size of Lerc blob in bytes
-                               struct LercInfo& lercInfo);
+      unsigned int numBytesBlob,   // size of Lerc blob in bytes
+      struct LercInfo& lercInfo,
+      double* pMins = nullptr,     // pass array of size (nDim * nBands) to get the min values per dimension and band
+      double* pMaxs = nullptr,     // same as pMins, to get the max values
+      size_t nElem = 0);           // (nDim * nBands), if passed
 
     // setup outgoing arrays accordingly, then call Decode()
 
@@ -218,8 +221,11 @@ NAMESPACE_LERC_START
 
     template<class T> static bool Resize(std::vector<T>& buffer, size_t nElem);
 
-    bool static Convert(const Byte* pByteMask, int nCols, int nRows, BitMask& bitMask);
-    bool static Convert(const BitMask& bitMask, Byte* pByteMask);
-    bool static MasksDiffer(const Byte* p0, const Byte* p1, size_t n);
+    static bool Convert(const Byte* pByteMask, int nCols, int nRows, BitMask& bitMask);
+    static bool Convert(const BitMask& bitMask, Byte* pByteMask);
+    static bool MasksDiffer(const Byte* p0, const Byte* p1, size_t n);
+
+    static ErrCode GetRanges(const Byte* pLercBlob, unsigned int numBytesBlob, int iBand,
+      const struct Lerc2::HeaderInfo& lerc2Info, double* pMins, double* pMaxs, size_t nElem);
   };
 NAMESPACE_LERC_END

--- a/src/LercLib/Lerc2.h
+++ b/src/LercLib/Lerc2.h
@@ -114,6 +114,8 @@ public:
 
   static bool GetHeaderInfo(const Byte* pByte, size_t nBytesRemaining, struct HeaderInfo& headerInfo, bool& bHasMask);
 
+  bool GetRanges(const Byte* pByte, size_t nBytesRemaining, double* pMins, double* pMaxs);
+
   /// dst buffer already allocated;  byte ptr is moved like a file pointer
   template<class T>
   bool Decode(const Byte** ppByte, size_t& nBytesRemaining, T* arr, Byte* pMaskBits = nullptr);    // if mask ptr is not 0, mask bits are returned (even if all valid or same as previous)
@@ -443,7 +445,7 @@ inline int Lerc2::ReduceDataType(T z, DataType dt, DataType& dtReduced)
   {
     case DT_Short:
     {
-      signed char c = (z >= -128 && z <= 127) ? (signed char)z : 0;
+      signed char c = (z >= (double)-128 && z <= 127) ? (signed char)z : 0;    // avoid signed / unsigned warnings on some compilers
       int tc = (T)c == z ? 2 : (T)b == z ? 1 : 0;
       dtReduced = (DataType)(dt - tc);
       return tc;
@@ -456,7 +458,7 @@ inline int Lerc2::ReduceDataType(T z, DataType dt, DataType& dtReduced)
     }
     case DT_Int:
     {
-      short s = (z >= SHRT_MIN && z <= SHRT_MAX) ? (short)z : 0;
+      short s = (z >= (double)SHRT_MIN && z <= SHRT_MAX) ? (short)z : 0;
       unsigned short us = (z >= 0 && z <= USHRT_MAX) ? (unsigned short)z : 0;
       int tc = (T)b == z ? 3 : (T)s == z ? 2 : (T)us == z ? 1 : 0;
       dtReduced = (DataType)(dt - tc);
@@ -471,15 +473,15 @@ inline int Lerc2::ReduceDataType(T z, DataType dt, DataType& dtReduced)
     }
     case DT_Float:
     {
-      short s = (z >= SHRT_MIN && z <= SHRT_MAX) ? (short)z : 0;
+      short s = (z >= (float)SHRT_MIN && z <= SHRT_MAX) ? (short)z : 0;
       int tc = (T)b == z ? 2 : (T)s == z ? 1 : 0;
       dtReduced = tc == 0 ? dt : (tc == 1 ? DT_Short : DT_Byte);
       return tc;
     }
     case DT_Double:
     {
-      short s = (z >= SHRT_MIN && z <= SHRT_MAX) ? (short)z : 0;
-      int l = (z >= INT_MIN && z <= INT_MAX) ? (int)z : 0;
+      short s = (z >= (double)SHRT_MIN && z <= SHRT_MAX) ? (short)z : 0;
+      int l = (z >= (double)INT_MIN && z <= (double)INT_MAX) ? (int)z : 0;
       float f = (z >= -FLT_MAX && z <= FLT_MAX) ? (float)z : 0;
       int tc = (T)s == z ? 3 : (T)l == z ? 2 : (T)f == z ? 1 : 0;
       dtReduced = tc == 0 ? dt : (DataType)(dt - 2 * tc + 1);
@@ -497,7 +499,7 @@ inline int Lerc2::ReduceDataType(T z, DataType dt, DataType& dtReduced)
 
 inline Lerc2::DataType Lerc2::ValidateDataType(int dt)
 {
-  if( dt >= DT_Char && dt <= DT_Double )
+  if (dt >= DT_Char && dt <= DT_Double)
     return static_cast<DataType>(dt);
   return DT_Undefined;
 }

--- a/src/LercLib/Lerc_c_api_impl.cpp
+++ b/src/LercLib/Lerc_c_api_impl.cpp
@@ -146,6 +146,22 @@ lerc_status lerc_getBlobInfo(const unsigned char* pLercBlob, unsigned int blobSi
 
 // -------------------------------------------------------------------------- ;
 
+lerc_status lerc_getDataRanges(const unsigned char* pLercBlob, unsigned int blobSize,
+  int nDim, int nBands, double* pMins, double* pMaxs)
+{
+  if (!pLercBlob || !blobSize || !pMins || !pMaxs || nDim <= 0 || nBands <= 0)
+    return (lerc_status)ErrCode::WrongParam;
+
+  Lerc::LercInfo lercInfo;
+  ErrCode errCode = Lerc::GetLercInfo(pLercBlob, blobSize, lercInfo, pMins, pMaxs, (size_t)nDim * (size_t)nBands);
+  if (errCode != ErrCode::Ok)
+    return (lerc_status)errCode;
+
+  return (lerc_status)ErrCode::Ok;
+}
+
+// -------------------------------------------------------------------------- ;
+
 lerc_status lerc_decode(const unsigned char* pLercBlob, unsigned int blobSize, int nMasks,
   unsigned char* pValidBytes, int nDim, int nCols, int nRows, int nBands, unsigned int dataType, void* pData)
 {

--- a/src/LercLib/include/Lerc_c_api.h
+++ b/src/LercLib/include/Lerc_c_api.h
@@ -172,6 +172,21 @@ extern "C" {
     int infoArraySize,                 // number of elements of infoArray
     int dataRangeArraySize);           // number of elements of dataRangeArray
 
+  //! Call this to quickly get the data ranges [min, max] per dimension and band without having to decode the pixels. Optional.
+  //! The 2 output data arrays must have been allocated to the same size (nDim * nBands).
+  //! The output data array's layout is an image with nDim columns and nBands rows.
+
+  LERCDLL_API
+#ifdef USE_EMSCRIPTEN
+    EMSCRIPTEN_KEEPALIVE
+#endif
+    lerc_status lerc_getDataRanges(
+      const unsigned char* pLercBlob,    // Lerc blob to decode
+      unsigned int blobSize,             // blob size in bytes
+      int nDim,                          // number of values per pixel (e.g., 3 for RGB, data is stored as [RGB, RGB, ...])
+      int nBands,                        // number of bands (e.g., 3 for [RRRR ..., GGGG ..., BBBB ...])
+      double* pMins,                     // outgoing minima per dimension and band
+      double* pMaxs);                    // outgoing maxima per dimension and band
 
   //! Decode the compressed Lerc blob into a raw data array.
   //! The data array must have been allocated to size (nDim * nCols * nRows * nBands * sizeof(dataType)).


### PR DESCRIPTION
Add a new, optional function to the C API to quickly get the data ranges per band and depth without having to decode the pixels. 