### PR TITLE
Please set SOVERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,10 @@ set_target_properties(Lerc
     PUBLIC_HEADER "src/LercLib/include/Lerc_types.h;src/LercLib/include/Lerc_c_api.h")
 
 if(BUILD_SHARED_LIBS)
-    set_target_properties(Lerc PROPERTIES DEFINE_SYMBOL LERC_EXPORTS)
+    set_target_properties(Lerc
+        PROPERTIES
+        SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
+        DEFINE_SYMBOL LERC_EXPORTS)
 endif()
 
 install(


### PR DESCRIPTION
Please consider to set the SOVERSION when generating a shared object.
In the patch provided in this PR the project mayor version number has bee used.
Of course the SOVERSION should be updated in future releases to ensure that ABI changes do not break the backward compatibility.