### PR TITLE
Add the ability to use the system libLerc

### DIFF
--- a/OtherLanguages/Python/lerc/_lerc.py
+++ b/OtherLanguages/Python/lerc/_lerc.py
@@ -39,14 +39,27 @@ import ctypes as ct
 from timeit import default_timer as timer
 import platform
 import os
-dir_path = os.path.dirname(os.path.realpath(__file__))
 
-if platform.system() == "Windows":
-    lercDll = ct.CDLL (os.path.join(dir_path, 'Lerc.dll'))
-if platform.system() == "Linux":
-    lercDll = ct.CDLL (os.path.join(dir_path, 'Lerc.so'))
-if platform.system() == "Darwin":
-    lercDll = ct.CDLL (os.path.join(dir_path, 'Lerc.dylib'))
+def _get_lib():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+
+    if platform.system() == "Windows":
+        lib = os.path.join(dir_path, 'Lerc.dll')
+    elif platform.system() == "Linux":
+        lib = os.path.join(dir_path, 'Lerc.so')
+    elif platform.system() == "Darwin":
+        lib = os.path.join(dir_path, 'Lerc.dylib')
+    else:
+        lib = None
+
+    if not lib or not os.path.exists(lib):
+        import ctypes.util
+        lib = ctypes.util.find_library('Lerc')
+
+    return lib
+
+lercDll = ct.CDLL (_get_lib())
+del _get_lib
 
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR implements a simple mechanism to allow the python bindings to use the system libLerc if a local copy of ``Lerc.so`` is not found.
This feature is very useful e.g. for packagers of GNU/Linux distributions in which the system policy imposes to use the shared copy of a library when available.

Please also note that the ``dir_path`` variable definition has been moved form the global scope to the ``_get_lib` function scope (because it is only used there).

In principle this is a backward incompatible change because the ``lerc`` module now no longer has a ``dir_path`` attribute.
This detail can be reverted anyway, just let me know.
