### PR TITLE
Tmaurer3/fix v22 decode short blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+* The older Lerc codec v2.2 (used around 2016) required 3 extra padding bytes at the end of the Lerc blob. If those padding bytes are missing, Lerc decode could fail. With this fix, decode works on such v2.2 Lerc blobs with missing padding bytes. 
+
 ### Added
 
 * Using [Emscripten](https://emscripten.org/), we compiled the Lerc C++ code into web assembly, resulting in a [new JS Lerc decoder](https://github.com/Esri/lerc/tree/master/OtherLanguages/js/dist). From now on, updates to the Lerc C++ code will be converted to JS automatically.

--- a/src/LercLib/BitStuffer2.cpp
+++ b/src/LercLib/BitStuffer2.cpp
@@ -349,7 +349,7 @@ void BitStuffer2::BitStuff_Before_Lerc2v3(Byte** ppByte, const vector<unsigned i
 // -------------------------------------------------------------------------- ;
 
 bool BitStuffer2::BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesRemaining, 
-    vector<unsigned int>& dataVec, unsigned int numElements, int numBits)
+    vector<unsigned int>& dataVec, unsigned int numElements, int numBits) const
 {
   if (numElements == 0 || numBits >= 32)
     return false;
@@ -360,36 +360,31 @@ bool BitStuffer2::BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesR
   size_t numUInts = (size_t)numUIntsLL;
   size_t numBytes = (size_t)numBytesLL;    // could theoretically overflow on 32 bit system
 
-  if (numBytes != numBytesLL || nBytesRemaining < numBytes)
+  unsigned int ntbnn = NumTailBytesNotNeeded(numElements, numBits);
+
+  if (numBytes != numBytesLL || nBytesRemaining + ntbnn < numBytes)
     return false;
 
   try
   {
     dataVec.resize(numElements, 0);    // init with 0
+    m_tmpBitStuffVec.resize(numUInts);
   }
   catch (const std::exception&)
   {
     return false;
   }
 
-  unsigned int* arr = (unsigned int*)(*ppByte);
-  unsigned int* srcPtr = arr;
-  srcPtr += numUInts - 1;
+  m_tmpBitStuffVec[numUInts - 1] = 0;    // set last uint to 0
 
-  // needed to save the 0-3 bytes not used in the last UInt
-  unsigned int lastUInt = *srcPtr;
-  unsigned int numBytesNotNeeded = NumTailBytesNotNeeded(numElements, numBits);
+  unsigned int nBytesToCopy = (numElements * numBits + 7) / 8;
+  memcpy(&m_tmpBitStuffVec[0], *ppByte, nBytesToCopy);
 
-  for (unsigned int n = numBytesNotNeeded; n; n--)
-  {
-    unsigned int val;
-    memcpy(&val, srcPtr, sizeof(unsigned int));
-    val <<= 8;
-    memcpy(srcPtr, &val, sizeof(unsigned int));
-  }
+  unsigned int* pLastULong = &m_tmpBitStuffVec[numUInts - 1];
+  while (ntbnn--)
+    *pLastULong <<= 8;
 
-  // do the un-stuffing
-  srcPtr = arr;
+  unsigned int* srcPtr = &m_tmpBitStuffVec[0];
   unsigned int* dstPtr = &dataVec[0];
   int bitPos = 0;
 
@@ -422,11 +417,9 @@ bool BitStuffer2::BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesR
     }
   }
 
-  if (numBytesNotNeeded > 0)
-    memcpy(srcPtr, &lastUInt, sizeof(unsigned int));  // restore the last UInt
+  *ppByte += nBytesToCopy;
+  nBytesRemaining -= nBytesToCopy;
 
-  *ppByte += numBytes - numBytesNotNeeded;
-  nBytesRemaining -= numBytes - numBytesNotNeeded;
   return true;
 }
 

--- a/src/LercLib/BitStuffer2.h
+++ b/src/LercLib/BitStuffer2.h
@@ -53,7 +53,7 @@ private:
   mutable std::vector<unsigned int>  m_tmpLutVec, m_tmpIndexVec, m_tmpBitStuffVec;
 
   static void BitStuff_Before_Lerc2v3(Byte** ppByte, const std::vector<unsigned int>& dataVec, int numBits);
-  static bool BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesRemaining, std::vector<unsigned int>& dataVec, unsigned int numElements, int numBits);
+  bool BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesRemaining, std::vector<unsigned int>& dataVec, unsigned int numElements, int numBits) const;
   void BitStuff(Byte** ppByte, const std::vector<unsigned int>& dataVec, int numBits) const;
   bool BitUnStuff(const Byte** ppByte, size_t& nBytesRemaining, std::vector<unsigned int>& dataVec, unsigned int numElements, int numBits) const;
 


### PR DESCRIPTION
_ fixes issue https://github.com/Esri/lerc/issues/197
_ make Lerc decoder robust against incorrectly written older v2.2 Lerc blobs with missing tail padding bytes
