### PR TITLE
BitUnStuff_Before_Lerc2v3(): avoid harmless unsigned-integer-overflow

### DIFF
--- a/src/LercLib/BitStuffer2.cpp
+++ b/src/LercLib/BitStuffer2.cpp
@@ -381,8 +381,11 @@ bool BitStuffer2::BitUnStuff_Before_Lerc2v3(const Byte** ppByte, size_t& nBytesR
   memcpy(&m_tmpBitStuffVec[0], *ppByte, nBytesToCopy);
 
   unsigned int* pLastULong = &m_tmpBitStuffVec[numUInts - 1];
-  while (ntbnn--)
+  while (ntbnn)
+  {
+    -- ntbnn;
     *pLastULong <<= 8;
+  }
 
   unsigned int* srcPtr = &m_tmpBitStuffVec[0];
   unsigned int* dstPtr = &dataVec[0];


### PR DESCRIPTION
c970d4a113dae004ce51f7a4c81e34d18b06b771 introduced an harmless
unsigned-integer-overflow. This is not a bug here, but GDAL uses the
-fsanitize=unsigned-integer-overflow OSSFuzz setting to detect real
issues, so let's avoid running into this situation.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46564
Upstreaming of https://github.com/OSGeo/gdal/commit/85453c23e4fe645bb476c423a58b2049b6465a81