### PR TITLE
Add const to data pointer

### DIFF
--- a/src/LercLib/Lerc.cpp
+++ b/src/LercLib/Lerc.cpp
@@ -180,7 +180,7 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
   // only if not Lerc2, try legacy Lerc1
   unsigned int numBytesHeaderBand0 = CntZImage::computeNumBytesNeededToReadHeader(false);
   unsigned int numBytesHeaderBand1 = CntZImage::computeNumBytesNeededToReadHeader(true);
-  Byte* pByte = const_cast<Byte*>(pLercBlob);
+  const Byte* pByte = pLercBlob;
 
   lercInfo.zMin =  FLT_MAX;
   lercInfo.zMax = -FLT_MAX;
@@ -194,7 +194,7 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
     if (nBytesRead < nBytesNeeded)
       return ErrCode::Failed;
 
-    Byte* ptr = const_cast<Byte*>(pLercBlob);
+    const Byte* ptr = pLercBlob;
     ptr += 10 + 2 * sizeof(int);
 
     int height(0), width(0);
@@ -212,7 +212,7 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
     lercInfo.dt = Lerc::DT_Float;
     lercInfo.maxZError = maxZErrorInFile;
 
-    Byte* pByte = const_cast<Byte*>(pLercBlob);
+    pByte = pLercBlob;
     bool onlyZPart = false;
 
     while (lercInfo.blobSize + numBytesHeaderBand1 < numBytesBlob)    // means there could be another band
@@ -469,7 +469,7 @@ ErrCode Lerc::DecodeTempl(T* pData, const Byte* pLercBlob, unsigned int numBytes
 #ifdef HAVE_LERC1_DECODE
     unsigned int numBytesHeaderBand0 = CntZImage::computeNumBytesNeededToReadHeader(false);
     unsigned int numBytesHeaderBand1 = CntZImage::computeNumBytesNeededToReadHeader(true);
-    Byte* pByte1 = const_cast<Byte*>(pLercBlob);
+    const Byte* pByte1 = pLercBlob;
     CntZImage zImg;
 
     for (int iBand = 0; iBand < nBands; iBand++)

--- a/src/LercLib/Lerc1Decode/BitStuffer.cpp
+++ b/src/LercLib/Lerc1Decode/BitStuffer.cpp
@@ -29,7 +29,7 @@ using namespace LercNS;
 
 // -------------------------------------------------------------------------- ;
 
-bool BitStuffer::read(Byte** ppByte, vector<unsigned int>& dataVec) const
+bool BitStuffer::read(const Byte** ppByte, vector<unsigned int>& dataVec) const
 {
   if (!ppByte)
     return false;
@@ -117,9 +117,9 @@ bool BitStuffer::read(Byte** ppByte, vector<unsigned int>& dataVec) const
 // -------------------------------------------------------------------------- ;
 // -------------------------------------------------------------------------- ;
 
-bool BitStuffer::readUInt(Byte** ppByte, unsigned int& k, int numBytes)
+bool BitStuffer::readUInt(const Byte** ppByte, unsigned int& k, int numBytes)
 {
-  Byte* ptr = *ppByte;
+  const Byte* ptr = *ppByte;
 
   if (numBytes == 1)
   {

--- a/src/LercLib/Lerc1Decode/BitStuffer.h
+++ b/src/LercLib/Lerc1Decode/BitStuffer.h
@@ -39,12 +39,12 @@ public:
   BitStuffer()  {}
   virtual ~BitStuffer()  {}
 
-  bool read(Byte** ppByte, std::vector<unsigned int>& dataVec) const;
+  bool read(const Byte** ppByte, std::vector<unsigned int>& dataVec) const;
 
 protected:
   mutable std::vector<unsigned int>  m_tmpBitStuffVec;
 
-  static bool readUInt(Byte** ppByte, unsigned int& k, int numBytes);    // numBytes = 1, 2, or 4
+  static bool readUInt(const Byte** ppByte, unsigned int& k, int numBytes);    // numBytes = 1, 2, or 4
   static unsigned int numTailBytesNotNeeded(unsigned int numElem, int numBits);
 };
 

--- a/src/LercLib/Lerc1Decode/CntZImage.cpp
+++ b/src/LercLib/Lerc1Decode/CntZImage.cpp
@@ -69,7 +69,7 @@ unsigned int CntZImage::computeNumBytesNeededToReadHeader(bool onlyZPart)
 
 // -------------------------------------------------------------------------- ;
 
-bool CntZImage::read(Byte** ppByte, double maxZError, bool onlyHeader, bool onlyZPart)
+bool CntZImage::read(const Byte** ppByte, double maxZError, bool onlyHeader, bool onlyZPart)
 {
   if (!ppByte || !*ppByte)
     return false;
@@ -85,7 +85,7 @@ bool CntZImage::read(Byte** ppByte, double maxZError, bool onlyHeader, bool only
   int version = 0, type = 0, width = 0, height = 0;
   double maxZErrorInFile = 0;
 
-  Byte* ptr = *ppByte;
+  const Byte* ptr = *ppByte;
 
   memcpy(&version, ptr, sizeof(int));  ptr += sizeof(int);
   memcpy(&type,    ptr, sizeof(int));  ptr += sizeof(int);
@@ -128,7 +128,7 @@ bool CntZImage::read(Byte** ppByte, double maxZError, bool onlyHeader, bool only
     int numTilesVert = 0, numTilesHori = 0, numBytes = 0;
     float maxValInImg = 0;
 
-    Byte* ptr = *ppByte;
+    const Byte* ptr = *ppByte;
 
     memcpy(&numTilesVert, ptr, sizeof(int));  ptr += sizeof(int);
     memcpy(&numTilesHori, ptr, sizeof(int));  ptr += sizeof(int);
@@ -136,7 +136,7 @@ bool CntZImage::read(Byte** ppByte, double maxZError, bool onlyHeader, bool only
     memcpy(&maxValInImg, ptr, sizeof(float));  ptr += sizeof(float);
 
     *ppByte = ptr;
-    Byte* bArr = ptr;
+    const Byte* bArr = ptr;
 
     SWAP_4(numTilesVert);
     SWAP_4(numTilesHori);
@@ -186,9 +186,9 @@ bool CntZImage::read(Byte** ppByte, double maxZError, bool onlyHeader, bool only
 // -------------------------------------------------------------------------- ;
 
 bool CntZImage::readTiles(bool zPart, double maxZErrorInFile, int numTilesVert, int numTilesHori,
-  float maxValInImg, Byte* bArr)
+  float maxValInImg, const Byte* bArr)
 {
-  Byte* ptr = bArr;
+  const Byte* ptr = bArr;
 
   for (int iTile = 0; iTile <= numTilesVert; iTile++)
   {
@@ -223,9 +223,9 @@ bool CntZImage::readTiles(bool zPart, double maxZErrorInFile, int numTilesVert, 
 
 // -------------------------------------------------------------------------- ;
 
-bool CntZImage::readCntTile(Byte** ppByte, int i0, int i1, int j0, int j1)
+bool CntZImage::readCntTile(const Byte** ppByte, int i0, int i1, int j0, int j1)
 {
-  Byte* ptr = *ppByte;
+  const Byte* ptr = *ppByte;
   int numPixel = (i1 - i0) * (j1 - j0);
 
   Byte comprFlag = *ptr++;
@@ -308,9 +308,9 @@ bool CntZImage::readCntTile(Byte** ppByte, int i0, int i1, int j0, int j1)
 
 // -------------------------------------------------------------------------- ;
 
-bool CntZImage::readZTile(Byte** ppByte, int i0, int i1, int j0, int j1, double maxZErrorInFile, float maxZInImg)
+bool CntZImage::readZTile(const Byte** ppByte, int i0, int i1, int j0, int j1, double maxZErrorInFile, float maxZInImg)
 {
-  Byte* ptr = *ppByte;
+  const Byte* ptr = *ppByte;
   int numPixel = 0;
 
   Byte comprFlag = *ptr++;
@@ -437,9 +437,9 @@ int CntZImage::numBytesFlt(float z)
 
 // -------------------------------------------------------------------------- ;
 
-bool CntZImage::readFlt(Byte** ppByte, float& z, int numBytes)
+bool CntZImage::readFlt(const Byte** ppByte, float& z, int numBytes)
 {
-  Byte* ptr = *ppByte;
+  const Byte* ptr = *ppByte;
 
   if (numBytes == 1)
   {

--- a/src/LercLib/Lerc1Decode/CntZImage.h
+++ b/src/LercLib/Lerc1Decode/CntZImage.h
@@ -47,7 +47,7 @@ public:
   static unsigned int computeNumBytesNeededToReadHeader(bool onlyZPart);
 
   /// read succeeds only if maxZError on file <= maxZError requested
-  bool read(Byte** ppByte, double maxZError, bool onlyHeader = false, bool onlyZPart = false);
+  bool read(const Byte** ppByte, double maxZError, bool onlyHeader = false, bool onlyZPart = false);
 
 protected:
 
@@ -65,13 +65,13 @@ protected:
     float maxZInImg;
   };
 
-  bool readTiles(bool zPart, double maxZErrorInFile, int numTilesVert, int numTilesHori, float maxValInImg, Byte* bArr);
+  bool readTiles(bool zPart, double maxZErrorInFile, int numTilesVert, int numTilesHori, float maxValInImg, const Byte* bArr);
 
-  bool readCntTile(Byte** ppByte, int i0, int i1, int j0, int j1);
-  bool readZTile(Byte** ppByte, int i0, int i1, int j0, int j1, double maxZErrorInFile, float maxZInImg);
+  bool readCntTile(const Byte** ppByte, int i0, int i1, int j0, int j1);
+  bool readZTile(const Byte** ppByte, int i0, int i1, int j0, int j1, double maxZErrorInFile, float maxZInImg);
 
   static int numBytesFlt(float z);    // returns 1, 2, or 4
-  static bool readFlt(Byte** ppByte, float& z, int numBytes);
+  static bool readFlt(const Byte** ppByte, float& z, int numBytes);
 
 protected:
 


### PR DESCRIPTION
Adding `const` to the pointer ensures the data won't be changed, while continuing to allow the pointer to be moved.