### PR TITLE
Python package v4 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,10 +25,10 @@ build/conda/output/
 
 cmake
 
-OtherLanguages/Python/lerc/Lerc.dll
-OtherLanguages/Python/lerc/Lerc.lib
-OtherLanguages/Python/lerc/Lerc.dylib
-OtherLanguages/Python/lerc/Lerc.so
+OtherLanguages/Python/lerc/*.dll
+OtherLanguages/Python/lerc/*.lib
+OtherLanguages/Python/lerc/*.dylib
+OtherLanguages/Python/lerc/*.so*
 /OtherLanguages/Python/build/
 /OtherLanguages/Python/dist/
 /OtherLanguages/Python/*.egg*

--- a/OtherLanguages/Python/lerc/_lerc.py
+++ b/OtherLanguages/Python/lerc/_lerc.py
@@ -124,9 +124,9 @@ def _get_lib():
     if platform.system() == "Windows":
         lib = os.path.join(dir_path, 'Lerc.dll')
     elif platform.system() == "Linux":
-        lib = os.path.join(dir_path, 'Lerc.so')
+        lib = os.path.join(dir_path, 'libLerc.so.4')
     elif platform.system() == "Darwin":
-        lib = os.path.join(dir_path, 'Lerc.dylib')
+        lib = os.path.join(dir_path, 'libLerc.dylib')
     else:
         lib = None
 

--- a/OtherLanguages/Python/setup.py
+++ b/OtherLanguages/Python/setup.py
@@ -16,7 +16,7 @@ except Exception:
 
 # Using MANIFEST.in doesn't respect relative paths above the package root.
 # Instead, inspect the location and copy in the binaries if newer.
-BINARY_TYPES = ["*.dll", "*.lib", "*.so", "*.dylib"]
+BINARY_TYPES = ["*.dll", "*.lib", "*.so*", "*.dylib"]
 PLATFORMS = ["Linux", "MacOS", "windows"]
 for platform in PLATFORMS:
     platform_dir = join("..", "..", "bin", platform)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Check out the Lerc decoders and encoders in `OtherLanguages/`. You may need to a
 
 ### Other download sites
 
-- [Lerc for Python / Conda](https://anaconda.org/conda-forge/lerc)
+- [Lerc for Python / Conda](https://anaconda.org/Esri/lerc)
 - [Lerc for JavaScript / npm](https://www.npmjs.com/package/lerc)
 
 ### How to compile LERC and the C++ test program

--- a/build/conda/lerc/meta.yaml
+++ b/build/conda/lerc/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: lerc
-  version: 3.0
+  version: 4.0
 
 build:
   noarch: python


### PR DESCRIPTION
This PR contains changes needed for publishing `lerc` python package `v4.0`:

- conda recipe version bump (to **4.0**).
- Updates for handling changes to binary file names/extensions (Linux and Mac OS).
- Fix for lerc conda python package URL in the README (current one points to C API binaries installation through conda-forge channel).

\
cc @scw 