### PR TITLE
renaming python package to pylerc + doc updated

### DIFF
--- a/OtherLanguages/Python/lerc/README.md
+++ b/OtherLanguages/Python/lerc/README.md
@@ -1,3 +1,7 @@
+## `pylerc` is the LERC Python package
+
+LERC is an open-source raster format which supports rapid encoding and decoding for any pixel type, with user-set maximum compression error per pixel.
+
 # What's new in Lerc 4.0?
 
 ## Option 1, uses numpy masked array

--- a/OtherLanguages/Python/setup.py
+++ b/OtherLanguages/Python/setup.py
@@ -1,12 +1,10 @@
 import setuptools
-import os
 
 from glob import glob
 from os.path import basename, exists, join, getmtime
 from shutil import copyfile
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
-readme_path = os.path.join(dir_path, "..", "..", "README.md")
+readme_path = join("lerc", "README.md")
 
 try:
     with open(readme_path, "r") as fh:
@@ -28,16 +26,17 @@ for platform in PLATFORMS:
                 copyfile(input_binary, output_binary)
 
 setuptools.setup(
-    name="lerc",
+    name="pylerc",
     version="4.0",
     author="esri",
     author_email="python@esri.com",
     description="Limited Error Raster Compression",
-    # long_description=long_description,
-    # long_description_content_type="text/markdown",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     license="Apache 2",
     url="https://github.com/Esri/lerc",
     packages=setuptools.find_packages(),
+    install_requires=["numpy"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Check out the Lerc decoders and encoders in `OtherLanguages/`. You may need to a
 
 ### Other download sites
 
-- [Lerc for Python / Conda](https://anaconda.org/Esri/lerc)
+- Lerc for Python (pylerc): [Conda](https://anaconda.org/Esri/pylerc) / [PyPI](https://pypi.org/project/pylerc/) (Note: The python package name is being renamed from `lerc` to `pylerc` in the next release- currently available under both names. However, the import name will remain the same (ie. `import lerc`).
 - [Lerc for JavaScript / npm](https://www.npmjs.com/package/lerc)
 - [Lerc conda-forge install](https://anaconda.org/conda-forge/lerc)
 

--- a/build/conda/lerc/meta.yaml
+++ b/build/conda/lerc/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: lerc
+  name: pylerc
   version: 4.0
 
 build:
@@ -25,7 +25,7 @@ test:
 
 about:
   description: |
-    LERC is an open-source raster format which supports rapid encoding and decoding
+    pylerc is the LERC Python package. LERC is an open-source raster format which supports rapid encoding and decoding
     for any pixel type, with user-set maximum compression error per pixel.
   home: https://esri.github.io/lerc/
   dev_url:  https://github.com/Esri/lerc


### PR DESCRIPTION
#240 

Initial changes related to renaming the python package from `lerc` to `pylerc`.

\
cc @scw 