### PR TITLE
JS: fix small mem leak when noData band exists in ndim data

### DIFF
--- a/OtherLanguages/js/src/Lerc.ts
+++ b/OtherLanguages/js/src/Lerc.ts
@@ -263,6 +263,7 @@ function initLercLib(lercFactory: LercFactory): void {
       bandCountWithNoData
     };
     if (bandCountWithNoData) {
+      _free(ptr);
       return headerInfo;
     }
     if (depthCount === 1 && bandCount === 1) {


### PR DESCRIPTION
A small memory that holds blob info wasn't released when nodata bands are encountered. This only happens when nDepth is more than 1 and when noData is actually used in one or more bands.