### PR TITLE
limit diff encode to int lossless

### DIFF
--- a/src/LercLib/Huffman.h
+++ b/src/LercLib/Huffman.h
@@ -176,7 +176,6 @@ inline bool Huffman::DecodeOneValue(const Byte** ppSrc, size_t& nBytesRemaining,
   }
 
   // if not there, go through the tree (slower)
-
   if (!m_root)
     return false;
 

--- a/src/LercLib/Lerc2.cpp
+++ b/src/LercLib/Lerc2.cpp
@@ -1422,7 +1422,7 @@ bool Lerc2::WriteTiles(const T* data, Byte** ppByte, int& numBytes) const
 
   const bool bDtInt = (hd.dt < DT_Float);
   const bool bIntLossless = bDtInt && (hd.maxZError == 0.5);
-  const bool bTryDiffEnc = (hd.version >= 5) && (nDepth > 1) && (hd.maxZError > 0);  // turn off for flt lossless
+  const bool bTryDiffEnc = (hd.version >= 5) && (nDepth > 1) && bIntLossless;  // only for int lossless to avoid error propagation
 
   const bool bCheckForIntOverflow = NeedToCheckForIntOverflow(hd);
   const bool bCheckForFltRndErr = NeedToCheckForFltRndErr(hd);

--- a/src/LercLib/Lerc2.h
+++ b/src/LercLib/Lerc2.h
@@ -106,7 +106,7 @@ public:
       numValidPixel,
       microBlockSize,
       blobSize,
-      nBlobsMore;         // for multi-band Lerc blob, how many more blobs or bands appended to this one
+      nBlobsMore;    // for multi-band Lerc blob, how many more blobs or bands appended to this one
 
     Byte bPassNoDataValues,  // 1 - pass noData values to decoder, 0 - don't pass, ignore
       bIsInt,    // 1 - float or double data is all integer numbers, 0 - not
@@ -435,8 +435,8 @@ inline int Lerc2::NumBytesTile(int numValidPixel, T zMin, T zMax, DataType dtZ, 
     unsigned int maxElem = (unsigned int)(maxVal + 0.5);
     if (maxElem > 0)
     {
-      nBytes += (!tryLut) ? m_bitStuffer2.ComputeNumBytesNeededSimple(numValidPixel, maxElem)
-                          : m_bitStuffer2.ComputeNumBytesNeededLut(sortedQuantVec, tryLut);
+      nBytes += (!tryLut) ? BitStuffer2::ComputeNumBytesNeededSimple(numValidPixel, maxElem)
+                          : BitStuffer2::ComputeNumBytesNeededLut(sortedQuantVec, tryLut);
     }
 
     if (nBytes < nBytesRaw)


### PR DESCRIPTION
For array per pixel, restrict relative encoding between slices to int lossless. To avoid error propagation. Also faster for not lossless. 