### PR TITLE
increase js version number and republish npm

### DIFF
--- a/OtherLanguages/js/package-lock.json
+++ b/OtherLanguages/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lerc",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lerc",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "~5.33.1",

--- a/OtherLanguages/js/package.json
+++ b/OtherLanguages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lerc",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "browser": "LercDecode.js",
   "bugs": {
     "url": "https://github.com/esri/lerc/issues"


### PR DESCRIPTION
package 4.0.2 was published from `js` root instead of `dist`.

cc @tmaurer3 