### PR TITLE
overflow safety

### DIFF
--- a/src/LercLib/BitMask.cpp
+++ b/src/LercLib/BitMask.cpp
@@ -102,7 +102,7 @@ int BitMask::CountValidBits() const
   const Byte numBitsHB[16] = {0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4};
   const Byte* ptr = m_pBits;
   int sum = 0;
-  int i = Size();
+  size_t i = Size();
   while (i--)
   {
     sum += numBitsHB[*ptr & 15] + numBitsHB[*ptr >> 4];

--- a/src/LercLib/BitMask.h
+++ b/src/LercLib/BitMask.h
@@ -59,7 +59,7 @@ public:
 
   int GetWidth() const                      { return m_nCols; }
   int GetHeight() const                     { return m_nRows; }
-  int Size() const                          { return (m_nCols * m_nRows + 7) >> 3; }
+  size_t Size() const                       { return ((size_t)m_nCols * m_nRows + 7) >> 3; }
   const Byte* Bits() const                  { return m_pBits; }
   Byte* Bits()                              { return m_pBits; }
   static Byte Bit(int k)                    { return (1 << 7) >> (k & 7); }


### PR DESCRIPTION
avoid possible int32 overflow