### PR TITLE
Add support for PEP 517.

### DIFF
--- a/OtherLanguages/Python/pyproject.toml
+++ b/OtherLanguages/Python/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Using `setup.py` directly is deprecated.