### PR TITLE
Pylerc v411 updates

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -29,7 +29,6 @@ jobs:
 
       - name: Build C++ Binaries (CMake)
         run: |
-          rm -rf cmake_build
           mkdir cmake_build
           cd cmake_build
           cmake .. -DCMAKE_BUILD_TYPE=Release
@@ -52,7 +51,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11' # Safe baseline to compile cross-compatible wheels
+          python-version: '3.11'
 
       - name: Build Wheel
         run: |

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -7,17 +7,13 @@ on:
       - 'OtherLanguages/Python/**'
       - 'src/**'
       - '.github/workflows/build_wheels.yml'
-    
     tags:
       - 'v*'
-
   pull_request:
     paths:
       - 'OtherLanguages/Python/**'
       - '.github/workflows/build_wheels.yml'
-  
   workflow_dispatch:
-
 
 jobs:
   build_wheels:
@@ -33,6 +29,7 @@ jobs:
 
       - name: Build C++ Binaries (CMake)
         run: |
+          rm -rf cmake_build
           mkdir cmake_build
           cd cmake_build
           cmake .. -DCMAKE_BUILD_TYPE=Release
@@ -55,13 +52,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.11' # Safe baseline to compile cross-compatible wheels
 
       - name: Build Wheel
         run: |
           python -m pip install --upgrade pip setuptools wheel build
           cd OtherLanguages/Python
-          python -m build
+          python -m build --wheel
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/OtherLanguages/Python/lerc/__init__.py
+++ b/OtherLanguages/Python/lerc/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.1"
+__version__ = "4.1.1"
 
 from ._lerc import *

--- a/OtherLanguages/Python/pyproject.toml
+++ b/OtherLanguages/Python/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/OtherLanguages/Python/setup.py
+++ b/OtherLanguages/Python/setup.py
@@ -26,8 +26,7 @@ try:
 except Exception:
     long_description = "Limited Error Raster Compression"
 
-# Using MANIFEST.in doesn't respect relative paths above the package root.
-# Instead, inspect the location and copy in the binaries if newer.
+# Stage binaries from repo root into package root
 BINARY_TYPES = ["*.dll", "*.lib", "*.so*", "*.dylib"]
 PLATFORMS = ["Linux", "MacOS", "windows"]
 for platform in PLATFORMS:
@@ -41,7 +40,7 @@ for platform in PLATFORMS:
 
 setuptools.setup(
     name="pylerc",
-    version="4.1",
+    version="4.1.1",
     author="esri",
     author_email="python@esri.com",
     description="Limited Error Raster Compression",
@@ -56,6 +55,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "License :: OSI Approved :: Apache Software License",
     ],
     package_data={"lerc": BINARY_TYPES},

--- a/build/conda/lerc/meta.yaml
+++ b/build/conda/lerc/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pylerc
-  version: 4.1
+  version: 4.1.1
 
 build:
   noarch: python


### PR DESCRIPTION
This PR contains the changes needed for publishing the `pylerc` Python package `v4.1.1` with official Python 3.14 support and surrounding build-related configuration updates.

\
cc @scw