### PR TITLE
tmaurer3/add_checks_for_data_volume_and_blob_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+* Added explicit size checks for the input data volume and the output compressed binary Lerc blob. The maximum data volume to encode is 2 GB per band. The maximum size of a compressed binary Lerc blob is set also to 2 GB per band, and 4 GB over all bands. The data volume over all bands is not limited as long as it can be compressed into 4 GB or less.
+
+* Coverity fixes and overflow checks.
+
 ## [4.1.1](https://github.com/Esri/lerc/releases/tag/v4.1.1) - 2026-07-02
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.12)
 project(Lerc
         DESCRIPTION "Limited Error Raster Compression"
         HOMEPAGE_URL "https://github.com/Esri/lerc"
-        VERSION 4.1.1) # Keep in sync with Lerc_c_api.h
+        VERSION 4.2.0) # Keep in sync with Lerc_c_api.h
 
 include(GNUInstallDirs)
 

--- a/build/windows/MS_VS2022/Lerc/Lerc.rc
+++ b/build/windows/MS_VS2022/Lerc/Lerc.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,1,1,0
- PRODUCTVERSION 4,1,1,0
+ FILEVERSION 4,2,0,0
+ PRODUCTVERSION 4,2,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -69,12 +69,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "ESRI"
             VALUE "FileDescription", "LERC Limited Error Raster Compression"
-            VALUE "FileVersion", "4.1.1.0"
+            VALUE "FileVersion", "4.2.0.0"
             VALUE "InternalName", "Lerc.dll"
             VALUE "LegalCopyright", "Copyright (C) 2015-2026"
             VALUE "OriginalFilename", "Lerc.dll"
             VALUE "ProductName", "LERC"
-            VALUE "ProductVersion", "4.1.1.0"
+            VALUE "ProductVersion", "4.2.0.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/LercLib/BitMask.cpp
+++ b/src/LercLib/BitMask.cpp
@@ -77,7 +77,7 @@ bool BitMask::SetSize(int nCols, int nRows)
 
     try
     {
-      size_t nPix = (size_t)nCols * (size_t)nRows;
+      size_t nPix = (size_t)nCols * nRows;
       m_pBits = new Byte[(nPix + 7) >> 3];
     }
     catch (...)
@@ -97,11 +97,11 @@ bool BitMask::SetSize(int nCols, int nRows)
 
 // -------------------------------------------------------------------------- ;
 
-int BitMask::CountValidBits() const
+int64_t BitMask::CountValidBits() const
 {
   const Byte numBitsHB[16] = {0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4};
   const Byte* ptr = m_pBits;
-  int sum = 0;
+  int64_t sum = 0;
   size_t i = Size();
   while (i--)
   {
@@ -110,7 +110,8 @@ int BitMask::CountValidBits() const
   }
 
   // subtract undefined bits potentially contained in the last byte
-  for (int k = m_nCols * m_nRows; k < Size() * 8; k++)
+  int64_t sizeX8 = (int64_t)(Size() * 8);
+  for (int64_t k = (int64_t)m_nCols * m_nRows; k < sizeX8; k++)
     if (IsValid(k))
       sum--;
 

--- a/src/LercLib/BitMask.h
+++ b/src/LercLib/BitMask.h
@@ -26,6 +26,7 @@ Contributors:  Thomas Maurer
 
 #include "Defines.h"
 #include <cstddef>
+#include <cstdint>
 
 NAMESPACE_LERC_START
 
@@ -39,19 +40,19 @@ public:
   BitMask() : m_pBits(nullptr), m_nCols(0), m_nRows(0)  {}
   BitMask(int nCols, int nRows) : m_pBits(nullptr), m_nCols(0), m_nRows(0) { SetSize(nCols, nRows); }
   BitMask(const BitMask& src);
-  ~BitMask()                        { Clear(); }
+  ~BitMask()                                { Clear(); }
 
   BitMask& operator= (const BitMask& src);
 
   // 1: valid, 0: not valid
-  Byte IsValid(int k) const                 { return (m_pBits[k >> 3] & Bit(k)) > 0; }
-  Byte IsValid(int row, int col) const      { return IsValid(row * m_nCols + col); }
+  Byte IsValid(int64_t k) const             { return (m_pBits[k >> 3] & Bit(k)) > 0; }
+  Byte IsValid(int row, int col) const      { return IsValid((int64_t)row * m_nCols + col); }
 
-  void SetValid(int k) const                { m_pBits[k >> 3] |= Bit(k); }
-  void SetValid(int row, int col) const     { SetValid(row * m_nCols + col); }
+  void SetValid(int64_t k) const            { m_pBits[k >> 3] |= Bit(k); }
+  void SetValid(int row, int col) const     { SetValid((int64_t)row * m_nCols + col); }
 
-  void SetInvalid(int k) const              { m_pBits[k >> 3] &= ~Bit(k); }
-  void SetInvalid(int row, int col) const   { SetInvalid(row * m_nCols + col); }
+  void SetInvalid(int64_t k) const          { m_pBits[k >> 3] &= ~Bit(k); }
+  void SetInvalid(int row, int col) const   { SetInvalid((int64_t)row * m_nCols + col); }
 
   void SetAllValid() const;
   void SetAllInvalid() const;
@@ -60,12 +61,12 @@ public:
 
   int GetWidth() const                      { return m_nCols; }
   int GetHeight() const                     { return m_nRows; }
-  size_t Size() const                       { return ((size_t)m_nCols * m_nRows + 7) >> 3; }
+  size_t Size() const                       { int64_t n = ((int64_t)m_nCols * m_nRows + 7) >> 3; return n >= 0 ? (size_t)n : 0; }
   const Byte* Bits() const                  { return m_pBits; }
   Byte* Bits()                              { return m_pBits; }
-  static Byte Bit(int k)                    { return (1 << 7) >> (k & 7); }
+  static Byte Bit(int64_t k)                { return (1 << 7) >> (k & 7); }
 
-  int CountValidBits() const;
+  int64_t CountValidBits() const;
   void Clear();
 
 private:

--- a/src/LercLib/Lerc.cpp
+++ b/src/LercLib/Lerc.cpp
@@ -100,12 +100,15 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
 
   if (Lerc2::GetHeaderInfo(pLercBlob, numBytesBlob, lerc2Info, bHasMask))
   {
+    if (lerc2Info.blobSize < 0)
+      return ErrCode::Failed;
+
     lercInfo.version = lerc2Info.version;
     lercInfo.nDepth = lerc2Info.nDepth;
     lercInfo.nCols = lerc2Info.nCols;
     lercInfo.nRows = lerc2Info.nRows;
     lercInfo.numValidPixel = lerc2Info.numValidPixel;    // for 1st band
-    lercInfo.blobSize = lerc2Info.blobSize;
+    lercInfo.blobSize = (unsigned int)lerc2Info.blobSize;  // blob size per band is in [0 .. 2 GB]
     lercInfo.dt = (DataType)lerc2Info.dt;
     lercInfo.zMin = lerc2Info.zMin;
     lercInfo.zMax = lerc2Info.zMax;
@@ -126,16 +129,17 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
 
     lercInfo.nBands = 1;
 
-    if (lercInfo.blobSize > (int)numBytesBlob)    // truncated blob, we won't be able to read this band
-      return ErrCode::BufferTooSmall;
+    if (lercInfo.blobSize > numBytesBlob)    // truncated blob, we won't be able to read this band
+      return ErrCode::Failed;
 
     struct Lerc2::HeaderInfo hdInfo;
     while (bTryNextBlob && Lerc2::GetHeaderInfo(pLercBlob + lercInfo.blobSize, numBytesBlob - lercInfo.blobSize, hdInfo, bHasMask))
     {
       if (hdInfo.nDepth != lercInfo.nDepth
-       || hdInfo.nCols != lercInfo.nCols
-       || hdInfo.nRows != lercInfo.nRows
-       || (int)hdInfo.dt != (int)lercInfo.dt)
+        || hdInfo.nCols != lercInfo.nCols
+        || hdInfo.nRows != lercInfo.nRows
+        || (int)hdInfo.dt != (int)lercInfo.dt
+        || hdInfo.blobSize < 0)
       {
         return ErrCode::Failed;
       }
@@ -148,11 +152,11 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
       if (bHasMask || hdInfo.numValidPixel != lercInfo.numValidPixel)    // support mask per band
         nMasks = 2;
 
-      if (lercInfo.blobSize > std::numeric_limits<int>::max() - hdInfo.blobSize)    // guard against overflow
+      if ((size_t)lercInfo.blobSize > (size_t)UINT_MAX - hdInfo.blobSize)    // guard against overflow
         return ErrCode::Failed;
 
-      if (lercInfo.blobSize + hdInfo.blobSize > (int)numBytesBlob)    // truncated blob, we won't be able to read this band
-        return ErrCode::BufferTooSmall;
+      if ((size_t)lercInfo.blobSize + hdInfo.blobSize > (size_t)numBytesBlob)    // truncated blob, we won't be able to read this band
+        return ErrCode::Failed;
 
       lercInfo.zMin = min(lercInfo.zMin, hdInfo.zMin);
       lercInfo.zMax = max(lercInfo.zMax, hdInfo.zMax);
@@ -206,6 +210,9 @@ ErrCode Lerc::GetLercInfo(const Byte* pLercBlob, unsigned int numBytesBlob, stru
     memcpy(&maxZErrorInFile, ptr, sizeof(double));
 
     if (height < 0 || width < 0 || height > 40000 || width > 40000)  // guard against bogus numbers; size limitation for old Lerc1
+      return ErrCode::Failed;
+
+    if (sizeof(CntZ) * height * width > (size_t)INT_MAX)
       return ErrCode::Failed;
 
     lercInfo.nDepth = 1;
@@ -324,6 +331,9 @@ ErrCode Lerc::ComputeCompressedSizeTempl(const T* pData, int version, int nDepth
   if (!(nMasks == 0 || nMasks == 1 || nMasks == nBands) || (nMasks > 0 && !pValidBytes))
     return ErrCode::WrongParam;
 
+  if (!CheckDimensions(nDepth, nCols, nRows, sizeof(T)))
+    return ErrCode::DimensionsTooLarge;
+
   unsigned int numBytesWritten = 0;
 
   if (version >= 0 && version <= 5)
@@ -358,6 +368,9 @@ ErrCode Lerc::EncodeTempl(const T* pData, int version, int nDepth, int nCols, in
   if (!(nMasks == 0 || nMasks == 1 || nMasks == nBands) || (nMasks > 0 && !pValidBytes))
     return ErrCode::WrongParam;
 
+  if (!CheckDimensions(nDepth, nCols, nRows, sizeof(T)))
+    return ErrCode::DimensionsTooLarge;
+
   memset(pBuffer, 0, (size_t)numBytesBuffer);
 
   unsigned int numBytesNeeded = 0;
@@ -391,6 +404,9 @@ ErrCode Lerc::DecodeTempl(T* pData, const Byte* pLercBlob, unsigned int numBytes
 
   if (!(nMasks == 0 || nMasks == 1 || nMasks == nBands) || (nMasks > 0 && !pValidBytes))
     return ErrCode::WrongParam;
+
+  if (!CheckDimensions(nDepth, nCols, nRows, sizeof(T)))
+    return ErrCode::DimensionsTooLarge;
 
   const Byte* pByte = pLercBlob;
   Lerc2::HeaderInfo hdInfo;
@@ -436,11 +452,11 @@ ErrCode Lerc::DecodeTempl(T* pData, const Byte* pLercBlob, unsigned int numBytes
     {
       if (((size_t)(pByte - pLercBlob) < numBytesBlob) && Lerc2::GetHeaderInfo(pByte, nBytesRemaining, hdInfo, bHasMask))
       {
-        if (hdInfo.nDepth != nDepth || hdInfo.nCols != nCols || hdInfo.nRows != nRows)
+        if (hdInfo.nDepth != nDepth || hdInfo.nCols != nCols || hdInfo.nRows != nRows || hdInfo.blobSize < 0)
           return ErrCode::Failed;
 
-        if ((pByte - pLercBlob) + (size_t)hdInfo.blobSize > numBytesBlob)
-          return ErrCode::BufferTooSmall;
+        if ((pByte - pLercBlob) + (size_t)hdInfo.blobSize > numBytesBlob)  // corrupted blob
+          return ErrCode::Failed;
 
         size_t nPix = (size_t)iBand * nRows * nCols;
         T* arr = pData + nPix * nDepth;
@@ -479,8 +495,8 @@ ErrCode Lerc::DecodeTempl(T* pData, const Byte* pLercBlob, unsigned int numBytes
     for (int iBand = 0; iBand < nBands; iBand++)
     {
       unsigned int numBytesHeader = iBand == 0 ? numBytesHeaderBand0 : numBytesHeaderBand1;
-      if ((size_t)(pByte1 - pLercBlob) + numBytesHeader > numBytesBlob)
-        return ErrCode::BufferTooSmall;
+      if ((size_t)(pByte1 - pLercBlob) + numBytesHeader > numBytesBlob)  // corrupted blob or wrong nBands
+        return ErrCode::Failed;
 
       bool onlyZPart = iBand > 0;
       if (!zImg.read(&pByte1, pLercBlob + numBytesBlob, 1e12, false, onlyZPart))
@@ -587,6 +603,9 @@ ErrCode Lerc::EncodeInternal_v5(const T* pData, int version, int nDepth, int nCo
     unsigned int nBytes = lerc2.ComputeNumBytesNeededToWrite(arr, maxZErr, bEncMsk);
     if (nBytes <= 0)
       return ErrCode::Failed;
+
+    if ((size_t)numBytesNeeded + nBytes > (size_t)UINT_MAX)  // keep total blob size (over all bands) <= 4 GB
+      return ErrCode::DimensionsTooLarge;
 
     numBytesNeeded += nBytes;
 
@@ -734,6 +753,9 @@ ErrCode Lerc::EncodeInternal(const T* pData, int version, int nDepth, int nCols,
     unsigned int nBytes = lerc2.ComputeNumBytesNeededToWrite(arrL, maxZErrL, bEncMsk);
     if (nBytes <= 0)
       return ErrCode::Failed;
+
+    if ((size_t)numBytesNeeded + nBytes > (size_t)UINT_MAX)  // keep total blob size (over all bands) <= 4 GB
+      return ErrCode::DimensionsTooLarge;
 
     numBytesNeeded += nBytes;
 
@@ -1248,7 +1270,7 @@ ErrCode Lerc::FilterNoData(std::vector<T>& dataBuffer, std::vector<Byte>& maskBu
   // check for noData in valid pixels
   for (int k = 0, i = 0; i < nRows; i++)
   {
-    T* rowArr = &(dataBuffer[i * nCols * nDepth]);
+    T* rowArr = &(dataBuffer[(size_t)i * nCols * nDepth]);
 
     for (int n = 0, j = 0; j < nCols; j++, k++, n += nDepth)
       if (maskBuffer[k])
@@ -1332,7 +1354,7 @@ ErrCode Lerc::FilterNoData(std::vector<T>& dataBuffer, std::vector<Byte>& maskBu
     {
       for (int k = 0, i = 0; i < nRows; i++)
       {
-        T* rowArr = &(dataBuffer[i * nCols * nDepth]);
+        T* rowArr = &(dataBuffer[(size_t)i * nCols * nDepth]);
 
         for (int n = 0, j = 0; j < nCols; j++, k++, n += nDepth)
           if (maskBuffer[k])
@@ -1505,7 +1527,7 @@ ErrCode Lerc::FilterNoDataAndNaN(std::vector<T>& dataBuffer, std::vector<Byte>& 
       {
         for (int k = 0, i = 0; i < nRows; i++)
         {
-          T* rowArr = &(dataBuffer[i * nCols * nDepth]);
+          T* rowArr = &(dataBuffer[(size_t)i * nCols * nDepth]);
 
           for (int n = 0, j = 0; j < nCols; j++, k++, n += nDepth)
             if (maskBuffer[k])
@@ -1597,3 +1619,23 @@ bool Lerc::FindNewNoDataBelowValidMin(double minVal, double maxZErr, bool bAllIn
 
 // -------------------------------------------------------------------------- ;
 
+bool Lerc::CheckDimensions(int nDepth, int nCols, int nRows, size_t sizeOfDataElement)
+{
+  // here we guard against too large input dimensions that might cause a possible int32 overflow later;
+  // we limit the size of input data per band to 2 GB, so any product [height * width * depth * sizeof(data element)] <= INT_MAX;
+  // (see the corresponding size and dimension checks in Lerc2::ReadHeader(...));
+
+  if (nDepth <= 0 || nCols <= 0 || nRows <= 0)
+    return false;
+
+  const uint64_t numPixel = (uint64_t)nRows * nCols;
+  const uint64_t maxint32 = (uint64_t)INT_MAX;
+  const uint64_t nbpp = sizeOfDataElement;
+
+  if (numPixel > maxint32 || nbpp > maxint32 || nbpp * nDepth > maxint32 || nbpp * nDepth * numPixel > maxint32)
+    return false;
+
+  return true;
+}
+
+// -------------------------------------------------------------------------- ;

--- a/src/LercLib/Lerc.h
+++ b/src/LercLib/Lerc.h
@@ -103,9 +103,9 @@ NAMESPACE_LERC_START
         nCols,            // number of columns
         nRows,            // number of rows
         numValidPixel,    // number of valid pixels
-        nBands,           // number of bands
-        blobSize,         // total blob size in bytes
-        nMasks,           // number of masks (0, 1, or nBands)
+        nBands;           // number of bands
+      unsigned int blobSize;  // total blob size in bytes, <= 4 GB
+      int nMasks,         // number of masks (0, 1, or nBands)
         nUsesNoDataValue; // 0 - no noData value used, nBands - noData value used in 1 or more bands (only possible for nDepth > 1)
       DataType dt;        // data type (float only for old Lerc1)
       double zMin,        // min pixel value, over all data values
@@ -282,5 +282,7 @@ NAMESPACE_LERC_START
 
     template<class T>
     static bool FindNewNoDataBelowValidMin(double minVal, double maxZErr, bool bAllInt, double lowIntLimit, T& newNoDataVal);
+
+    static bool CheckDimensions(int nDepth, int nCols, int nRows, size_t sizeOfDataElement);
   };
 NAMESPACE_LERC_END

--- a/src/LercLib/Lerc1Decode/CntZImage.cpp
+++ b/src/LercLib/Lerc1Decode/CntZImage.cpp
@@ -21,6 +21,7 @@ http://github.com/Esri/lerc/
 Contributors:  Thomas Maurer
 */
 
+#include <climits>
 #include <cstring>
 #include <algorithm>
 #include "CntZImage.h"
@@ -48,7 +49,7 @@ bool CntZImage::resizeFill0(int width, int height)
   if (!resize(width, height))
     return false;
 
-  memset(getData(), 0, width * height * sizeof(CntZ));
+  memset(getData(), 0, sizeof(CntZ) * width * height);
   return true;
 }
 
@@ -114,6 +115,9 @@ bool CntZImage::read(const Byte** ppByte, const Byte* bArr_end, double maxZError
   if (height < 0 || width < 0 || height > 40000 || width > 40000)  // guard against bogus numbers; size limitation for old Lerc1
     return false;
 
+  if (sizeof(CntZ) * height * width > (size_t)INT_MAX)
+    return false;
+
   if (maxZErrorInFile > maxZError)
     return false;
 
@@ -177,7 +181,7 @@ bool CntZImage::read(const Byte** ppByte, const Byte* bArr_end, double maxZError
         // decompress to bit mask
         BitMask bitMask(width_, height_);
         RLE rle;
-        if (!rle.decompress(bArr, width_ * height_ * 2, (Byte*)bitMask.Bits(), bitMask.Size()))
+        if (!rle.decompress(bArr, (size_t)width_ * height_ * 2, (Byte*)bitMask.Bits(), bitMask.Size()))
           return false;
 
         CntZ* dstPtr = getData();

--- a/src/LercLib/Lerc1Decode/TImage.hpp
+++ b/src/LercLib/Lerc1Decode/TImage.hpp
@@ -88,7 +88,7 @@ bool TImage< Element >::resize(int width, int height)
   width_ = 0;
   height_ = 0;
 
-  data_ = (Element*)malloc(width * height * sizeof(Element));
+  data_ = (Element*)malloc(sizeof(Element) * width * height);
   if (!data_)
     return false;
 

--- a/src/LercLib/Lerc2.cpp
+++ b/src/LercLib/Lerc2.cpp
@@ -91,7 +91,12 @@ bool Lerc2::Set(int nDepth, int nCols, int nRows, const Byte* pMaskBits)
   if (pMaskBits)
   {
     memcpy(m_bitMask.Bits(), pMaskBits, m_bitMask.Size());
-    m_headerInfo.numValidPixel = m_bitMask.CountValidBits();
+
+    int64_t numValid = m_bitMask.CountValidBits();
+    if (numValid < 0 || numValid > (int64_t)INT_MAX)
+      return false;
+
+    m_headerInfo.numValidPixel = (int)numValid;
   }
   else
   {
@@ -256,7 +261,14 @@ unsigned int Lerc2::ComputeNumBytesNeededToWrite(const T* arr, double maxZError,
   {
     // add the min max ranges behind the mask and before the main data;
     // so we do not write it if no valid pixel or all same value const
-    m_headerInfo.blobSize += 2 * nDepth * sizeof(T);
+
+    size_t currBlobSize = m_headerInfo.blobSize;
+    currBlobSize += sizeof(T) * nDepth * 2;
+
+    if (currBlobSize > (size_t)INT_MAX)  // limit Lerc blob size per band to 2 GB
+      return 0;
+
+    m_headerInfo.blobSize = (int)currBlobSize;
 
     bool minMaxEqual = false;
     if (!CheckMinMaxRanges(minMaxEqual))
@@ -267,7 +279,7 @@ unsigned int Lerc2::ComputeNumBytesNeededToWrite(const T* arr, double maxZError,
   }
 
   // data
-  if (!WriteTiles(arr, &ptr, nBytesTiling))
+  if (!WriteTiles(arr, &ptr, nBytesTiling) || nBytesTiling < 0)
     return 0;
 
   m_imageEncodeMode = IEM_Tiling;
@@ -278,6 +290,9 @@ unsigned int Lerc2::ComputeNumBytesNeededToWrite(const T* arr, double maxZError,
   {
     ImageEncodeMode huffmanEncMode;
     ComputeHuffmanCodes(arr, nBytesHuffman, huffmanEncMode, m_huffmanCodes);    // save Huffman codes for later use
+
+    if (nBytesHuffman < 0)
+      nBytesHuffman = INT_MAX;
 
     if (!m_huffmanCodes.empty() && nBytesHuffman < nBytesTiling)
     {
@@ -294,12 +309,15 @@ unsigned int Lerc2::ComputeNumBytesNeededToWrite(const T* arr, double maxZError,
     bool rv = m_lfpc.ComputeHuffmanCodesFlt(arr, (m_headerInfo.dt == DT_Double),
       m_headerInfo.nCols, m_headerInfo.nRows, m_headerInfo.nDepth);
 
-    if (!rv)    // remove this check before next release to fall back to regular Lerc instead of fail
+    if (!rv)
       return 0;
 
     if (rv)
     {
       nBytesHuffman = m_lfpc.compressedLength();
+
+      if (nBytesHuffman < 0)
+        nBytesHuffman = INT_MAX;
 
       if (nBytesHuffman < nBytesTiling * 0.9)    // demand at least 10% better than not Huffman
       {
@@ -310,19 +328,19 @@ unsigned int Lerc2::ComputeNumBytesNeededToWrite(const T* arr, double maxZError,
   }
 
   m_writeDataOneSweep = false;
-  int nBytesDataOneSweep = (int)(numValid * nDepth * sizeof(T));
+  size_t nBytesDataOneSweep = sizeof(T) * nDepth * numValid;
 
   {
     // try with double block size to reduce block header overhead, if
     if (((size_t)nBytesTiling * 8 < (size_t)numTotal * nDepth * 1.5)    // resulting bit rate < x (2 bpp)
-      && (nBytesTiling < 4 * nBytesDataOneSweep)     // bit stuffing is effective
-      && (nBytesHuffman == 0 || nBytesTiling < 2 * nBytesHuffman)    // not much worse than huffman (otherwise huffman wins anyway)
+      && ((size_t)nBytesTiling < 4 * nBytesDataOneSweep)     // bit stuffing is effective
+      && (nBytesHuffman == 0 || (size_t)nBytesTiling < (size_t)2 * nBytesHuffman)    // not much worse than huffman (otherwise huffman wins anyway)
       && (m_headerInfo.nRows > m_microBlockSize || m_headerInfo.nCols > m_microBlockSize))
     {
       m_headerInfo.microBlockSize = m_microBlockSize * 2;
 
       int nBytes2 = 0;
-      if (!WriteTiles(arr, &ptr, nBytes2))    // no huffman in here anymore
+      if (!WriteTiles(arr, &ptr, nBytes2) || nBytes2 < 0)    // no huffman in here anymore
         return 0;
 
       if (nBytes2 <= nBytesData)
@@ -341,16 +359,23 @@ unsigned int Lerc2::ComputeNumBytesNeededToWrite(const T* arr, double maxZError,
   if (m_headerInfo.TryHuffmanInt() || m_headerInfo.TryHuffmanFlt())
     nBytesData += 1;    // flag for image encode mode
 
-  if (nBytesDataOneSweep <= nBytesData)
+  size_t totalBlobSize = m_headerInfo.blobSize;
+
+  if (nBytesDataOneSweep <= (size_t)nBytesData)
   {
     m_writeDataOneSweep = true;    // fallback: write data binary uncompressed in one sweep
-    m_headerInfo.blobSize += 1 + nBytesDataOneSweep;    // header, mask, min max ranges, flag, data one sweep
+    totalBlobSize += 1 + nBytesDataOneSweep;  // header, mask, min max ranges, flag, data one sweep
   }
   else
   {
     m_writeDataOneSweep = false;
-    m_headerInfo.blobSize += 1 + nBytesData;    // header, mask, min max ranges, flag(s), data
+    totalBlobSize += 1 + nBytesData;  // header, mask, min max ranges, flag(s), data
   }
+
+  if (totalBlobSize > (size_t)INT_MAX)  // limit Lerc blob size per band to 2 GB
+    return 0;
+
+  m_headerInfo.blobSize = (int)totalBlobSize;
 
   return m_headerInfo.blobSize;
 }
@@ -442,7 +467,7 @@ bool Lerc2::Encode(const T* arr, Byte** ppByte)
     }
 
     int numBytes = 0;
-    if (!WriteTiles(arr, ppByte, numBytes))
+    if (!WriteTiles(arr, ppByte, numBytes) || numBytes < 0)
       return false;
   }
   else
@@ -871,9 +896,20 @@ bool Lerc2::ReadHeader(const Byte** ppByte, size_t& nBytesRemainingInOut, struct
   hd.noDataVal      = (hd.version >= 6) ? dblVec[i++] : 0;
   hd.noDataValOrig  = (hd.version >= 6) ? dblVec[i++] : 0;
 
-  size_t numPixel = (size_t)hd.nRows * hd.nCols;
+  // here we guard against bogus input parameters and dimensions:
+  // we limit the size of input data per band to 2 GB, so any product [height * width * depth * sizeof(data element)] <= INT_MAX;
+  // the size of a compressed binary Lerc blob per band is <= 2 GB;
+  // the total size of a compressed binary Lerc blob over all bands is <= 4 GB (current Lerc API limitation);
+  // (see the corresponding size and dimension checks in Lerc::CheckDimensions(...));
 
-  if (numPixel > (size_t)INT_MAX || (size_t)hd.numValidPixel > numPixel)
+  const uint64_t numPixel = (uint64_t)hd.nRows * hd.nCols;
+  const uint64_t maxint32 = (uint64_t)INT_MAX;
+  const uint64_t nbpp = GetDataTypeSize(hd.dt);
+
+  if (numPixel > maxint32 || (uint64_t)hd.numValidPixel > numPixel)
+    return false;
+
+  if (hd.microBlockSize > 128 || nbpp * hd.nDepth > maxint32 || nbpp * hd.nDepth * numPixel > maxint32)
     return false;
 
   *ppByte = ptr;
@@ -1050,7 +1086,7 @@ bool Lerc2::TryBitPlaneCompression(const T* data, double eps, double& newMaxZErr
   if (hd.numValidPixel < minCnt)    // not enough data for good stats
     return false;
 
-  std::vector<int> cntDiffVec(nDepth * maxShift, 0);
+  std::vector<int> cntDiffVec((size_t)nDepth * maxShift, 0);
   int cnt = 0;
 
   if (nDepth == 1 && hd.numValidPixel == hd.nCols * hd.nRows)    // special but common case
@@ -1340,9 +1376,13 @@ bool Lerc2::ReadDataOneSweep(const Byte** ppByte, size_t& nBytesRemaining, T* da
   const Byte* ptr = (*ppByte);
   const HeaderInfo& hd = m_headerInfo;
   int nDepth = hd.nDepth;
-  int len = nDepth * sizeof(T);
+  size_t len = sizeof(T) * nDepth;
 
-  size_t nValidPix = (size_t)m_bitMask.CountValidBits();
+  int64_t numValid = m_bitMask.CountValidBits();
+  if (numValid < 0 || numValid >(int64_t)INT_MAX)
+    return false;
+
+  size_t nValidPix = (size_t)numValid;
 
   if (nBytesRemaining < nValidPix * len)
     return false;
@@ -1449,7 +1489,7 @@ bool Lerc2::WriteTiles(const T* data, Byte** ppByte, int& numBytes) const
   int mbSize = hd.microBlockSize;
   int nDepth = hd.nDepth;
 
-  std::vector<T> dataVec(mbSize * mbSize, 0);
+  std::vector<T> dataVec((size_t)mbSize * mbSize, 0);
   T* dataBuf = &dataVec[0];
 
   const bool bDtInt = (hd.dt < DT_Float);
@@ -2100,7 +2140,7 @@ bool Lerc2::ReadTile(const Byte** ppByte, size_t& nBytesRemainingInOut, T* data,
     }
     else
     {
-      size_t maxElementCount = (i1 - i0) * (j1 - j0);
+      size_t maxElementCount = size_t(i1 - i0) * (j1 - j0);
       if (!m_bitStuffer2.Decode(&ptr, nBytesRemaining, bufferVec, maxElementCount, hd.version))
         return false;
 

--- a/src/LercLib/Lerc_c_api_impl.cpp
+++ b/src/LercLib/Lerc_c_api_impl.cpp
@@ -269,7 +269,10 @@ lerc_status lerc_decodeToDouble_4D(const unsigned char* pLercBlob, unsigned int 
     return (lerc_status)errCode;
 
   Lerc::DataType dt = lercInfo.dt;
-  if (dt > Lerc::DT_Double)
+  if (dt < 0 || dt > Lerc::DT_Double)
+    return (lerc_status)ErrCode::Failed;
+
+  if (lercInfo.nDepth != nDepth || lercInfo.nCols != nCols || lercInfo.nRows != nRows || lercInfo.nBands != nBands)
     return (lerc_status)ErrCode::Failed;
 
   if (dt == Lerc::DT_Double)
@@ -284,7 +287,7 @@ lerc_status lerc_decodeToDouble_4D(const unsigned char* pLercBlob, unsigned int 
   {
     // use the buffer passed for in place decode and convert
     int sizeofDt[] = { 1, 1, 2, 2, 4, 4, 4, 8 };
-    size_t nDataValues = nDepth * nCols * nRows * nBands;
+    size_t nDataValues = (size_t)nDepth * nCols * nRows * nBands;  // can be > 4 GB
     void* ptrDec = (Byte*)pData + nDataValues * (sizeof(double) - sizeofDt[dt]);
 
     if ((errCode = Lerc::Decode(pLercBlob, blobSize, nMasks, pValidBytes,

--- a/src/LercLib/include/Lerc_c_api.h
+++ b/src/LercLib/include/Lerc_c_api.h
@@ -37,8 +37,8 @@ extern "C" {
 /* LERC version numbers and related macros added in 3.0.0 */
 
 #define LERC_VERSION_MAJOR 4
-#define LERC_VERSION_MINOR 1
-#define LERC_VERSION_PATCH 1
+#define LERC_VERSION_MINOR 2
+#define LERC_VERSION_PATCH 0
 
 /* Macro to compute a LERC version number from its components */
 #define LERC_COMPUTE_VERSION(maj,min,patch) ((maj)*10000+(min)*100+(patch))
@@ -66,6 +66,25 @@ extern "C" {
 #endif
 
   //! C-API for LERC library
+
+
+  //! Added in version 4.2:
+  //!
+  //! Lerc is mainly used as an image tile compression format, usually not to compress an entire large
+  //! image into one single compressed binary file. While this is possible, it would not be optimal in
+  //! both compression and read / write access.
+  //!
+  //! Now we put some well defined size limitations in place. We don't expect this to have any
+  //! implications for typical usage scenarios when encoding image tiles. The main goal is improved
+  //! security and protection, both against accidental integer overflows thanks to wrong or too large
+  //! dimensions as well as bogus dimensions or parameters planted by an attacker into the binary Lerc
+  //! header of the compressed Lerc blob.
+  //!
+  //! - 1) The size of input data (to be encoded) is limited to 2 GB per band.
+  //! - 2) The size of the compressed binary Lerc blob is also limited to 2 GB per band.
+  //! - 3) The size of the entire compressed binary Lerc blob (over all bands) is limited to 4 GB.
+  //! - 4) The size of the entire input data (to be encoded, over all bands) is NOT limited, as long
+  //!      as the above conditions are met.
 
 
   //! Added in version 4.0: 

--- a/src/LercLib/include/Lerc_types.h
+++ b/src/LercLib/include/Lerc_types.h
@@ -15,7 +15,8 @@ namespace LercNS
     WrongParam,
     BufferTooSmall,
     NaN,
-    HasNoData
+    HasNoData,
+    DimensionsTooLarge
   };
 
   enum class DataType : int


### PR DESCRIPTION
Added explicit size checks for the input data volume and the output compressed binary Lerc blob. The maximum data volume to encode is 2 GB per band. The maximum size of a compressed binary Lerc blob is set also to 2 GB per band, and 4 GB over all bands. The data volume over all bands is not limited as long as it can be compressed into 4 GB or less.