### PR TITLE
  Fix uninitialized memory read in Lerc2::ReadMask on dimension change

### DIFF
--- a/src/LercLib/Lerc2.cpp
+++ b/src/LercLib/Lerc2.cpp
@@ -982,6 +982,15 @@ bool Lerc2::ReadMask(const Byte** ppByte, size_t& nBytesRemainingInOut)
   if ((numValid == 0 || numValid == w * h) && (numBytesMask != 0))
     return false;
 
+  if (numBytesMask < 0)
+    return false;
+
+  if (numBytesMask == 0 && !(numValid == 0 || numValid == w * h))
+  {
+    if (w != m_bitMask.GetWidth() || h != m_bitMask.GetHeight())
+      return false;
+  }
+
   if (!m_bitMask.SetSize(w, h))
     return false;
 


### PR DESCRIPTION
  Prevent a `use-of-uninitialized-value` bug when decoding LERC blobs where the mask is skipped/reused but image dimensions have changed.

  If `numBytesMask == 0` and the count of valid pixels is intermediate, Lerc2 attempts to reuse the existing mask. However, if the stream specifies new dimensions, `m_bitMask.SetSize(w, h)` reallocates the
 underlying buffer but does not initialize it. Attempting to "reuse" this newly allocated, uninitialized buffer causes downstream tools to read garbage memory.

  Changes:
  - Reject negative `numBytesMask` values.
  - Reject mask "reuse" (`numBytesMask == 0` with intermediate valid count) if the requested dimensions differ from the current mask dimensions.