### PR TITLE
release: bump pylerc to v4.2.0 and automate secure conda/pypi workflows

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,4 +1,4 @@
-name: Build Platform Wheels
+name: Build Platform Wheels and Conda Packages
 
 on:
   push:
@@ -6,18 +6,24 @@ on:
     paths:
       - 'OtherLanguages/Python/**'
       - 'src/**'
+      - 'build/conda/**'
       - '.github/workflows/build_wheels.yml'
     tags:
       - 'v*'
   pull_request:
     paths:
       - 'OtherLanguages/Python/**'
+      - 'src/**'
+      - 'build/conda/**'
       - '.github/workflows/build_wheels.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build_wheels:
-    name: Build on ${{ matrix.os }}
+    name: Build Wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -27,7 +33,24 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Build C++ Binaries (CMake)
+      - name: Build C++ Binaries (Linux Container Compatibility)
+        if: matrix.os == 'ubuntu-latest'
+        uses: addnab/docker-run-action@v3
+        with:
+          image: rockylinux:8
+          options: -v ${{ github.workspace }}:/workspace
+          run: |
+            dnf install -y gcc-c++ cmake make
+            cd /workspace
+            mkdir -p cmake_build
+            cd cmake_build
+            cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_RPATH="\$ORIGIN/../../..\$ORIGIN/../lib"
+            cmake --build . --config Release
+
+      - name: Build C++ Binaries (Windows & macOS Native)
+        if: matrix.os != 'ubuntu-latest'
+        env:
+          MACOSX_DEPLOYMENT_TARGET: '11.0'
         run: |
           mkdir cmake_build
           cd cmake_build
@@ -45,7 +68,9 @@ jobs:
           elif [ "${{ matrix.os }}" = "macos-latest" ]; then
             cp cmake_build/libLerc.dylib bin/MacOS/ || cp cmake_build/Release/libLerc.dylib bin/MacOS/ || echo "DYLIB not found"
           else
-            cp cmake_build/libLerc.so bin/Linux/ || cp cmake_build/Release/libLerc.so bin/Linux/ || echo "SO not found"
+            cp cmake_build/libLerc.so.4 bin/Linux/ || cp cmake_build/Release/libLerc.so.4 bin/Linux/ || \
+            cp cmake_build/libLerc.so bin/Linux/libLerc.so.4 || \
+            cp cmake_build/Release/libLerc.so bin/Linux/libLerc.so.4 || echo "libLerc.so.4 not found"
           fi
 
       - name: Set up Python
@@ -54,13 +79,84 @@ jobs:
           python-version: '3.11'
 
       - name: Build Wheel
+        env:
+          MACOSX_DEPLOYMENT_TARGET: '11.0'
         run: |
           python -m pip install --upgrade pip setuptools wheel build
           cd OtherLanguages/Python
+          python setup.py build
           python -m build --wheel
 
-      - name: Upload Artifacts
+      - name: Standardize Wheel Platform Labels
+        shell: bash
+        run: |
+          cd OtherLanguages/Python/dist/
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            for f in *linux_x86_64.whl; do [ -e "$f" ] && mv "$f" "${f/linux_x86_64/manylinux_2_28_x86_64}"; done
+          fi
+
+      - name: Upload Platform Wheel Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: pylerc-wheels-${{ matrix.os }}
           path: OtherLanguages/Python/dist/*.whl
+
+      - name: Upload Binary Snippets for Conda
+        uses: actions/upload-artifact@v4
+        with:
+          name: compiled-binaries-${{ matrix.os }}
+          path: bin/
+
+  build_conda:
+    name: Assemble Noarch Conda Package
+    needs: build_wheels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Download Windows Binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-binaries-windows-latest
+          path: bin/
+
+      - name: Download MacOS Binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-binaries-macos-latest
+          path: bin/
+
+      - name: Download Linux Binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-binaries-ubuntu-latest
+          path: bin/
+
+      - name: Setup Miniconda Environment
+        uses: conda-incubator/setup-miniconda@v4
+        with:
+          auto-update-conda: true
+          auto-activate: true
+          activate-environment: ""
+
+      - name: Install Conda Build Tooling
+        shell: bash -el {0}
+        run: conda install -y python=3.11 conda-build
+
+      - name: Build Noarch Conda Distribution
+        shell: bash -el {0}
+        run: |
+          cd OtherLanguages/Python
+          python setup.py build
+          cd ../..
+          mkdir -p conda-out
+          conda build build/conda/lerc/ --output-folder conda-out/
+
+      - name: Upload Conda Distribution Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pylerc-conda-package
+          path: conda-out/noarch/*.conda
+
+

--- a/OtherLanguages/Python/lerc/README.md
+++ b/OtherLanguages/Python/lerc/README.md
@@ -2,6 +2,13 @@
 
 LERC is an open-source raster format which supports rapid encoding and decoding for any pixel type, with user-set maximum compression error per pixel.
 
+# What's new in Lerc 4.2?
+
+Lerc 4.2 adds stricter size limits for improved safety:
+- Input data to encode is limited to 2 GB per band.
+- Compressed Lerc blob size is limited to 2 GB per band.
+- Total compressed Lerc blob size is limited to 4 GB across all bands.
+
 # What's new in Lerc 4.0?
 
 ## Option 1, uses numpy masked array

--- a/OtherLanguages/Python/lerc/__init__.py
+++ b/OtherLanguages/Python/lerc/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "4.1.1"
+__version__ = "4.2.0"
 
 from ._lerc import *

--- a/OtherLanguages/Python/setup.py
+++ b/OtherLanguages/Python/setup.py
@@ -40,7 +40,7 @@ for platform in PLATFORMS:
 
 setuptools.setup(
     name="pylerc",
-    version="4.1.1",
+    version="4.2.0",
     author="esri",
     author_email="python@esri.com",
     description="Limited Error Raster Compression",

--- a/build/conda/lerc/meta.yaml
+++ b/build/conda/lerc/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pylerc
-  version: 4.1.1
+  version: 4.2.0
 
 build:
   noarch: python


### PR DESCRIPTION
This PR contains the changes needed for publishing the `pylerc` Python package `v4.2.0`:

- **_Version Bumps_**: Updated `meta.yaml`, `setup.py`, and initialization files to v4.2.0.
- **_CI & Binary Automation_**: Automated all cross-platform binaries, PyPI wheels, and Conda package builds inside a secured workflow.
- **_Linux Optimization_**: Retargeted the Linux compilation pipeline to natively support backward-compatibility with GLIBC 2.28 (RHEL 8+).