### PR TITLE
Ci/macos universal binary

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Build C++ Binaries (Windows & macOS Native)
         if: matrix.os != 'ubuntu-latest'
+        shell: bash
         env:
           MACOSX_DEPLOYMENT_TARGET: '11.0'
         run: |

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -54,7 +54,11 @@ jobs:
         run: |
           mkdir cmake_build
           cd cmake_build
-          cmake .. -DCMAKE_BUILD_TYPE=Release
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
+          else
+            cmake .. -DCMAKE_BUILD_TYPE=Release
+          fi
           cmake --build . --config Release
 
       - name: Stage Binaries for setup.py


### PR DESCRIPTION
**_CI:_** Configure cmake pipeline to build macOS binaries as universal (x86_64 + arm64)